### PR TITLE
Replaced Tween Properties with Tween Resource

### DIFF
--- a/addons/phantom_camera/examples/2DExampleScene.tscn
+++ b/addons/phantom_camera/examples/2DExampleScene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://bds64oihh6xh6"]
+[gd_scene load_steps=17 format=3 uid="uid://bds64oihh6xh6"]
 
 [ext_resource type="Texture2D" uid="uid://c77npili4pel4" path="res://addons/phantom_camera/examples/textures/2D/level_spritesheet.png" id="1_1utlo"]
 [ext_resource type="Script" path="res://addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd" id="1_eayfa"]
@@ -6,8 +6,11 @@
 [ext_resource type="Script" path="res://addons/phantom_camera/examples/scripts/2D/PlayerCharacterBody2D.gd" id="4_jnuod"]
 [ext_resource type="FontFile" uid="uid://ca54suba27fmn" path="res://addons/phantom_camera/examples/fonts/NunitoSans-Black.ttf" id="6_akfb5"]
 [ext_resource type="Texture2D" uid="uid://cwep0on2tthn7" path="res://addons/phantom_camera/examples/textures/2D/PhantomCamera2DSprite.png" id="6_e46ea"]
+[ext_resource type="Resource" uid="uid://euybd2w0bax" path="res://addons/phantom_camera/examples/resources/tween/PlayerPhantomCamera2DTween.tres" id="6_gqov5"]
 [ext_resource type="PackedScene" path="res://addons/phantom_camera/examples/ui/UISign.tscn" id="6_kqt1v"]
 [ext_resource type="PackedScene" path="res://addons/phantom_camera/examples/ui/UIInventory.tscn" id="7_fdx1s"]
+[ext_resource type="Resource" uid="uid://cecrnq0wnkexh" path="res://addons/phantom_camera/examples/resources/tween/ItemFocusPhantomCamera2DTween.tres" id="10_0txyn"]
+[ext_resource type="Resource" uid="uid://cllveybboaqk5" path="res://addons/phantom_camera/examples/resources/tween/InventoryPhantomCamera2DTween.tres" id="11_xakux"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_easgx"]
 texture = ExtResource("1_1utlo")
@@ -641,9 +644,7 @@ Zoom = Vector2(1, 1)
 "Follow Parameters/Target Offset" = Vector2(0, -120)
 "Follow Parameters/Damping" = true
 "Follow Parameters/Damping Value" = 10.0
-"Tween Properties/Duration" = 0.3
-"Tween Properties/Transition" = 3
-"Tween Properties/Ease" = 1
+"Tween Parameters" = ExtResource("6_gqov5")
 
 [node name="CharacterBody2D" type="CharacterBody2D" parent="Player"]
 position = Vector2(243, -28)
@@ -723,9 +724,7 @@ script = ExtResource("2_mgsut")
 Priority = 0
 Zoom = Vector2(2, 2)
 "Follow Mode" = 0
-"Tween Properties/Duration" = 0.6
-"Tween Properties/Transition" = 8
-"Tween Properties/Ease" = 1
+"Tween Parameters" = ExtResource("10_0txyn")
 
 [node name="InventoryPhantomCamera2D" type="Node2D" parent="Player/CharacterBody2D"]
 unique_name_in_owner = true
@@ -734,9 +733,7 @@ script = ExtResource("2_mgsut")
 Priority = 0
 Zoom = Vector2(2.5, 2.5)
 "Follow Mode" = 0
-"Tween Properties/Duration" = 0.6
-"Tween Properties/Transition" = 5
-"Tween Properties/Ease" = 1
+"Tween Parameters" = ExtResource("11_xakux")
 
 [node name="Label" type="Label" parent="Player"]
 offset_left = 167.0

--- a/addons/phantom_camera/examples/2DGroupExampleScene.tscn
+++ b/addons/phantom_camera/examples/2DGroupExampleScene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://jwlmfyn3co4a"]
+[gd_scene load_steps=17 format=3 uid="uid://jwlmfyn3co4a"]
 
 [ext_resource type="Texture2D" uid="uid://c77npili4pel4" path="res://addons/phantom_camera/examples/textures/2D/level_spritesheet.png" id="1_5kqbp"]
 [ext_resource type="PackedScene" path="res://addons/phantom_camera/examples/ui/UIInventory.tscn" id="2_xmntp"]
@@ -7,7 +7,10 @@
 [ext_resource type="Texture2D" uid="uid://cwep0on2tthn7" path="res://addons/phantom_camera/examples/textures/2D/PhantomCamera2DSprite.png" id="5_0v2cd"]
 [ext_resource type="Script" path="res://addons/phantom_camera/scripts/phantom_camera/phantom_camera_2D.gd" id="6_diuy4"]
 [ext_resource type="Script" path="res://addons/phantom_camera/examples/scripts/2D/PlayerCharacterBody2D.gd" id="7_0pk2o"]
+[ext_resource type="Resource" uid="uid://euybd2w0bax" path="res://addons/phantom_camera/examples/resources/tween/PlayerPhantomCamera2DTween.tres" id="8_cx6vg"]
 [ext_resource type="FontFile" uid="uid://ca54suba27fmn" path="res://addons/phantom_camera/examples/fonts/NunitoSans-Black.ttf" id="8_xck10"]
+[ext_resource type="Resource" uid="uid://cecrnq0wnkexh" path="res://addons/phantom_camera/examples/resources/tween/ItemFocusPhantomCamera2DTween.tres" id="10_ar2rk"]
+[ext_resource type="Resource" uid="uid://cllveybboaqk5" path="res://addons/phantom_camera/examples/resources/tween/InventoryPhantomCamera2DTween.tres" id="11_5hu46"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_easgx"]
 texture = ExtResource("1_5kqbp")
@@ -624,7 +627,7 @@ visible = false
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(325, -222)
-zoom = Vector2(1.69558, 1.69558)
+zoom = Vector2(1.5102, 1.5102)
 
 [node name="PhantomCameraHost" type="Node" parent="Camera2D"]
 script = ExtResource("4_2efwt")
@@ -652,7 +655,7 @@ unique_name_in_owner = true
 position = Vector2(325, -222)
 script = ExtResource("6_diuy4")
 Priority = 6
-Zoom = Vector2(1.69558, 1.69558)
+Zoom = Vector2(1.5102, 1.5102)
 "Follow Mode" = 3
 "Follow Group" = Array[NodePath]([NodePath("../CharacterBody2D"), NodePath("../../GroupNPCSprite")])
 "Follow Parameters/Auto Zoom" = true
@@ -662,9 +665,7 @@ Zoom = Vector2(1.69558, 1.69558)
 "Follow Parameters/Target Offset" = Vector2(0, 0)
 "Follow Parameters/Damping" = true
 "Follow Parameters/Damping Value" = 8.0
-"Tween Properties/Duration" = 0.6
-"Tween Properties/Transition" = 3
-"Tween Properties/Ease" = 1
+"Tween Parameters" = ExtResource("8_cx6vg")
 
 [node name="CharacterBody2D" type="CharacterBody2D" parent="Player"]
 position = Vector2(243, -28)
@@ -744,9 +745,7 @@ script = ExtResource("6_diuy4")
 Priority = 0
 Zoom = Vector2(2, 2)
 "Follow Mode" = 0
-"Tween Properties/Duration" = 0.6
-"Tween Properties/Transition" = 8
-"Tween Properties/Ease" = 1
+"Tween Parameters" = ExtResource("10_ar2rk")
 
 [node name="InventoryPhantomCamera2D" type="Node2D" parent="Player/CharacterBody2D"]
 unique_name_in_owner = true
@@ -755,9 +754,7 @@ script = ExtResource("6_diuy4")
 Priority = 0
 Zoom = Vector2(2.5, 2.5)
 "Follow Mode" = 0
-"Tween Properties/Duration" = 0.3
-"Tween Properties/Transition" = 8
-"Tween Properties/Ease" = 1
+"Tween Parameters" = ExtResource("11_5hu46")
 
 [node name="Label2" type="Label" parent="Player"]
 offset_left = 49.0

--- a/addons/phantom_camera/examples/2DTweeningExampleScene.tscn
+++ b/addons/phantom_camera/examples/2DTweeningExampleScene.tscn
@@ -1,10 +1,12 @@
-[gd_scene load_steps=18 format=3 uid="uid://rru5m1vfbioq"]
+[gd_scene load_steps=23 format=3 uid="uid://rru5m1vfbioq"]
 
 [ext_resource type="Texture2D" uid="uid://c77npili4pel4" path="res://addons/phantom_camera/examples/textures/2D/level_spritesheet.png" id="1_oo2bo"]
 [ext_resource type="PackedScene" path="res://addons/phantom_camera/examples/ui/UIInventory.tscn" id="2_as4e6"]
 [ext_resource type="PackedScene" path="res://addons/phantom_camera/examples/ui/UISign.tscn" id="3_6yi7w"]
 [ext_resource type="Script" path="res://addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd" id="4_bb7en"]
 [ext_resource type="Script" path="res://addons/phantom_camera/scripts/phantom_camera/phantom_camera_2D.gd" id="5_kikl5"]
+[ext_resource type="Script" path="res://addons/phantom_camera/scripts/resources/tween_resource.gd" id="6_8u8cj"]
+[ext_resource type="Resource" uid="uid://euybd2w0bax" path="res://addons/phantom_camera/examples/resources/tween/PlayerPhantomCamera2DTween.tres" id="6_gu0o0"]
 [ext_resource type="Script" path="res://addons/phantom_camera/examples/scripts/2D/PlayerCharacterBody2D.gd" id="6_oxdpf"]
 [ext_resource type="FontFile" uid="uid://ca54suba27fmn" path="res://addons/phantom_camera/examples/fonts/NunitoSans-Black.ttf" id="7_2r7ct"]
 [ext_resource type="Texture2D" uid="uid://cwep0on2tthn7" path="res://addons/phantom_camera/examples/textures/2D/PhantomCamera2DSprite.png" id="8_ok3b7"]
@@ -582,11 +584,29 @@ size = Vector2(42, 57)
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_tgk1y"]
 size = Vector2(140, 160)
 
+[sub_resource type="Resource" id="Resource_ujs6q"]
+script = ExtResource("6_8u8cj")
+duration = 0.6
+transition = 1
+ease = 2
+
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_clm0y"]
 size = Vector2(104, 160)
 
+[sub_resource type="Resource" id="Resource_7xgkv"]
+script = ExtResource("6_8u8cj")
+duration = 0.3
+transition = 8
+ease = 2
+
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_uka0w"]
 size = Vector2(560, 160)
+
+[sub_resource type="Resource" id="Resource_tse25"]
+script = ExtResource("6_8u8cj")
+duration = 1.0
+transition = 10
+ease = 2
 
 [node name="ExampleScene2D" type="Node2D"]
 
@@ -651,9 +671,7 @@ Zoom = Vector2(1, 1)
 "Follow Parameters/Target Offset" = Vector2(0, -120)
 "Follow Parameters/Damping" = true
 "Follow Parameters/Damping Value" = 10.0
-"Tween Properties/Duration" = 0.6
-"Tween Properties/Transition" = 4
-"Tween Properties/Ease" = 1
+"Tween Parameters" = ExtResource("6_gu0o0")
 
 [node name="CharacterBody2D" type="CharacterBody2D" parent="Player"]
 position = Vector2(243, -28)
@@ -731,9 +749,7 @@ script = ExtResource("5_kikl5")
 Priority = 0
 Zoom = Vector2(2, 2)
 "Follow Mode" = 0
-"Tween Properties/Duration" = 0.6
-"Tween Properties/Transition" = 8
-"Tween Properties/Ease" = 1
+"Tween Parameters" = null
 
 [node name="InventoryPhantomCamera2D" type="Node2D" parent="Player/CharacterBody2D"]
 unique_name_in_owner = true
@@ -742,9 +758,7 @@ script = ExtResource("5_kikl5")
 Priority = 0
 Zoom = Vector2(2.5, 2.5)
 "Follow Mode" = 0
-"Tween Properties/Duration" = 0.6
-"Tween Properties/Transition" = 5
-"Tween Properties/Ease" = 1
+"Tween Parameters" = null
 
 [node name="Label" type="Label" parent="Player"]
 offset_left = 167.0
@@ -789,14 +803,12 @@ Duration:
 horizontal_alignment = 1
 
 [node name="PhantomCamera2D" type="Node2D" parent="WideArea"]
-position = Vector2(150, -17)
+position = Vector2(4, -100)
 script = ExtResource("5_kikl5")
 Priority = 0
 Zoom = Vector2(0.8, 0.8)
 "Follow Mode" = 0
-"Tween Properties/Duration" = 0.6
-"Tween Properties/Transition" = 1
-"Tween Properties/Ease" = 2
+"Tween Parameters" = SubResource("Resource_ujs6q")
 
 [node name="UpperZoomArea" type="Area2D" parent="." node_paths=PackedStringArray("area_pcam")]
 position = Vector2(649, -135)
@@ -836,9 +848,7 @@ script = ExtResource("5_kikl5")
 Priority = 0
 Zoom = Vector2(2, 2)
 "Follow Mode" = 0
-"Tween Properties/Duration" = 0.3
-"Tween Properties/Transition" = 8
-"Tween Properties/Ease" = 2
+"Tween Parameters" = SubResource("Resource_7xgkv")
 
 [node name="ForwardArea" type="Area2D" parent="." node_paths=PackedStringArray("area_pcam")]
 position = Vector2(1136, -38)
@@ -878,6 +888,4 @@ script = ExtResource("5_kikl5")
 Priority = 0
 Zoom = Vector2(0.9, 0.9)
 "Follow Mode" = 0
-"Tween Properties/Duration" = 1.2
-"Tween Properties/Transition" = 10
-"Tween Properties/Ease" = 2
+"Tween Parameters" = SubResource("Resource_tse25")

--- a/addons/phantom_camera/examples/3DExampleScene.tscn
+++ b/addons/phantom_camera/examples/3DExampleScene.tscn
@@ -1,12 +1,15 @@
-[gd_scene load_steps=31 format=3 uid="uid://c78dkupamejnm"]
+[gd_scene load_steps=35 format=3 uid="uid://cp8hqgpfi477l"]
 
 [ext_resource type="Script" path="res://addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd" id="1_1ouug"]
 [ext_resource type="Script" path="res://addons/phantom_camera/examples/scripts/3D/NPC.gd" id="2_2n1da"]
 [ext_resource type="FontFile" uid="uid://ca54suba27fmn" path="res://addons/phantom_camera/examples/fonts/NunitoSans-Black.ttf" id="2_ry7oc"]
 [ext_resource type="Script" path="res://addons/phantom_camera/scripts/phantom_camera/phantom_camera_3D.gd" id="2_y3dy8"]
 [ext_resource type="PackedScene" path="res://addons/phantom_camera/examples/models/3DPrototypeCubeDark.tscn" id="3_f5qrw"]
+[ext_resource type="Resource" uid="uid://cptfoggk2ok67" path="res://addons/phantom_camera/examples/resources/tween/PlayerPhantomCamera3DTween.tres" id="4_7kvsv"]
+[ext_resource type="Script" path="res://addons/phantom_camera/scripts/resources/tween_resource.gd" id="4_d1mkp"]
 [ext_resource type="Script" path="res://addons/phantom_camera/examples/scripts/3D/3D_trigger_area.gd" id="4_moad5"]
 [ext_resource type="Script" path="res://addons/phantom_camera/examples/scripts/3D/player_controller.gd" id="5_c85ys"]
+[ext_resource type="Resource" uid="uid://c1v786g5agaw5" path="res://addons/phantom_camera/examples/resources/tween/FixedCameraTween.tres" id="7_qeha2"]
 
 [sub_resource type="CapsuleMesh" id="CapsuleMesh_g0eml"]
 
@@ -14,6 +17,12 @@
 albedo_color = Color(0.988235, 0.498039, 0.498039, 1)
 
 [sub_resource type="CapsuleShape3D" id="CapsuleShape3D_dy1i7"]
+
+[sub_resource type="Resource" id="Resource_cye0i"]
+script = ExtResource("4_d1mkp")
+duration = 0.9
+transition = 4
+ease = 2
 
 [sub_resource type="BoxMesh" id="BoxMesh_7tjw4"]
 size = Vector3(2, 0.5, 4)
@@ -106,9 +115,7 @@ Priority = 3
 "Follow Parameters/Damping" = true
 "Follow Parameters/Damping Value" = 15.0
 "Look At Mode" = 0
-"Tween Properties/Duration" = 0.6
-"Tween Properties/Transition" = 4
-"Tween Properties/Ease" = 2
+"Tween Parameters" = ExtResource("4_7kvsv")
 
 [node name="PlayerCharacterBody3D" type="CharacterBody3D" parent="PlayerGroup"]
 unique_name_in_owner = true
@@ -137,9 +144,7 @@ script = ExtResource("2_y3dy8")
 Priority = 0
 "Follow Mode" = 0
 "Look At Mode" = 0
-"Tween Properties/Duration" = 0.9
-"Tween Properties/Transition" = 4
-"Tween Properties/Ease" = 2
+"Tween Parameters" = SubResource("Resource_cye0i")
 
 [node name="NPCDescriptionLabel" type="Label3D" parent="NPCGroup"]
 transform = Transform3D(1, 0, 0, 0, 0.866026, 0.5, 0, -0.5, 0.866025, -3.04693, 0.367287, 0.953757)
@@ -201,8 +206,7 @@ script = ExtResource("2_y3dy8")
 Priority = 0
 "Follow Mode" = 0
 "Look At Mode" = 0
-"Tween Properties/Duration" = 0.0
-"Tween Properties/Transition" = 0
+"Tween Parameters" = ExtResource("7_qeha2")
 
 [node name="NorthRoomTrigger" type="Area3D" parent="FixedCameraTriggerZone" node_paths=PackedStringArray("area_pcam")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 3, -0.45, -0.9)
@@ -221,8 +225,7 @@ script = ExtResource("2_y3dy8")
 Priority = 0
 "Follow Mode" = 0
 "Look At Mode" = 0
-"Tween Properties/Duration" = 0.0
-"Tween Properties/Transition" = 0
+"Tween Parameters" = ExtResource("7_qeha2")
 
 [node name="EntryRoomTrigger" type="Area3D" parent="FixedCameraTriggerZone" node_paths=PackedStringArray("area_pcam")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 3, -0.45, 3)
@@ -241,8 +244,7 @@ script = ExtResource("2_y3dy8")
 Priority = 0
 "Follow Mode" = 0
 "Look At Mode" = 0
-"Tween Properties/Duration" = 0.0
-"Tween Properties/Transition" = 0
+"Tween Parameters" = ExtResource("7_qeha2")
 
 [node name="SouthRoomTrigger" type="Area3D" parent="FixedCameraTriggerZone" node_paths=PackedStringArray("area_pcam")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 3, -0.45, 6.7)

--- a/addons/phantom_camera/examples/3DFollowGluedExampleScene.tscn
+++ b/addons/phantom_camera/examples/3DFollowGluedExampleScene.tscn
@@ -50,18 +50,16 @@ Priority = 5
 "Follow Parameters/Damping" = true
 "Follow Parameters/Damping Value" = 5.0
 "Look At Mode" = 0
-"Tween Properties/Duration" = 0.6
-"Tween Properties/Transition" = 5
-"Tween Properties/Ease" = 2
+"Tween Parameters" = null
 
 [node name="PlayerCharacterBody3D" type="CharacterBody3D" parent="Player"]
 unique_name_in_owner = true
 transform = Transform3D(0.999897, 0.0143636, 0, -0.0143636, 0.999897, 0, 0, 0, 1, -11.2101, 6.38964, 6.74731)
 script = ExtResource("4_hehj7")
+enable_gravity = false
 metadata/_edit_group_ = true
 
 [node name="PlayerMeshInstance3D" type="MeshInstance3D" parent="Player/PlayerCharacterBody3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 visible = false
 mesh = SubResource("CapsuleMesh_pda7a")
 surface_material_override/0 = SubResource("StandardMaterial3D_u74j7")
@@ -80,7 +78,6 @@ transform = Transform3D(0.999897, 0.0143636, 0, -0.0143636, 0.999897, 0, 0, 0, 1
 metadata/_edit_group_ = true
 
 [node name="PlayerMeshInstance3D" type="MeshInstance3D" parent="Player/PlayerCharacterBody3D2"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 mesh = SubResource("CapsuleMesh_pda7a")
 surface_material_override/0 = SubResource("StandardMaterial3D_u74j7")
 

--- a/addons/phantom_camera/examples/3DLookAtExampleScene.tscn
+++ b/addons/phantom_camera/examples/3DLookAtExampleScene.tscn
@@ -30,7 +30,7 @@ uv1_world_triplanar = true
 
 [node name="MainCamera3D" type="Camera3D" parent="."]
 unique_name_in_owner = true
-transform = Transform3D(0.999882, -0.012416, 0.00879777, 0, 0.578153, 0.815928, -0.015217, -0.815834, 0.578086, -11.9975, 8.41762, 7.01051)
+transform = Transform3D(0.999882, -0.0124227, 0.00880248, 0, 0.578153, 0.815928, -0.0152252, -0.815834, 0.578085, -11.9975, 8.41762, 7.01051)
 
 [node name="PhantomCameraHost" type="Node" parent="MainCamera3D"]
 script = ExtResource("1_lldvu")
@@ -42,16 +42,14 @@ metadata/_edit_lock_ = true
 [node name="Player" type="Node" parent="."]
 
 [node name="PlayerPhantomCamera3D" type="Node3D" parent="Player"]
-transform = Transform3D(0.999838, -0.0124152, 0.00879591, 0, 0.577995, 0.815929, -0.0152163, -0.815784, 0.577963, -11.9975, 8.41762, 7.01051)
+transform = Transform3D(0.999838, -0.0124219, 0.00880062, 0, 0.577995, 0.815929, -0.0152245, -0.815784, 0.577963, -11.9975, 8.41762, 7.01051)
 script = ExtResource("2_8md3q")
 Priority = 5
 "Follow Mode" = 0
 "Look At Mode" = 2
 "Look At Target" = NodePath("../PlayerCharacterBody3D2")
 "Look At Parameters/Look At Target Offset" = Vector3(0, 0, 0)
-"Tween Properties/Duration" = 0.6
-"Tween Properties/Transition" = 5
-"Tween Properties/Ease" = 2
+"Tween Parameters" = null
 
 [node name="PlayerCharacterBody3D2" type="CharacterBody3D" parent="Player"]
 unique_name_in_owner = true

--- a/addons/phantom_camera/examples/3DTweeningExampleScene.tscn
+++ b/addons/phantom_camera/examples/3DTweeningExampleScene.tscn
@@ -1,11 +1,13 @@
-[gd_scene load_steps=13 format=3 uid="uid://bgmv422o6hlx3"]
+[gd_scene load_steps=19 format=3 uid="uid://bgmv422o6hlx3"]
 
 [ext_resource type="PackedScene" path="res://addons/phantom_camera/examples/models/3DPrototypeCubeDark.tscn" id="1_ydeog"]
 [ext_resource type="Script" path="res://addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd" id="2_b2yrt"]
 [ext_resource type="Script" path="res://addons/phantom_camera/scripts/phantom_camera/phantom_camera_3D.gd" id="3_m2w30"]
 [ext_resource type="Script" path="res://addons/phantom_camera/examples/scripts/3D/player_controller.gd" id="4_68dqc"]
+[ext_resource type="Resource" uid="uid://cptfoggk2ok67" path="res://addons/phantom_camera/examples/resources/tween/PlayerPhantomCamera3DTween.tres" id="4_aj0kl"]
 [ext_resource type="Script" path="res://addons/phantom_camera/examples/scripts/3D/3D_trigger_area.gd" id="5_h0ouh"]
 [ext_resource type="FontFile" uid="uid://ca54suba27fmn" path="res://addons/phantom_camera/examples/fonts/NunitoSans-Black.ttf" id="6_hw5af"]
+[ext_resource type="Script" path="res://addons/phantom_camera/scripts/resources/tween_resource.gd" id="6_wup4d"]
 
 [sub_resource type="CapsuleMesh" id="CapsuleMesh_qde4k"]
 
@@ -23,6 +25,30 @@ size = Vector3(5, 0.1, 4)
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_2dct5"]
 transparency = 1
 albedo_color = Color(0.988235, 0.478431, 0.905882, 0.0901961)
+
+[sub_resource type="Resource" id="Resource_hml7x"]
+script = ExtResource("6_wup4d")
+duration = 0.6
+transition = 0
+ease = 2
+
+[sub_resource type="Resource" id="Resource_pjwwe"]
+script = ExtResource("6_wup4d")
+duration = 0.3
+transition = 1
+ease = 2
+
+[sub_resource type="Resource" id="Resource_ex8sv"]
+script = ExtResource("6_wup4d")
+duration = 0.3
+transition = 8
+ease = 2
+
+[sub_resource type="Resource" id="Resource_n4qdq"]
+script = ExtResource("6_wup4d")
+duration = 1.2
+transition = 10
+ease = 2
 
 [node name="Root" type="Node3D"]
 
@@ -56,9 +82,7 @@ Priority = 3
 "Follow Parameters/Damping" = true
 "Follow Parameters/Damping Value" = 10.0
 "Look At Mode" = 0
-"Tween Properties/Duration" = 0.9
-"Tween Properties/Transition" = 5
-"Tween Properties/Ease" = 2
+"Tween Parameters" = ExtResource("4_aj0kl")
 
 [node name="PlayerCharacterBody3D" type="CharacterBody3D" parent="."]
 unique_name_in_owner = true
@@ -105,8 +129,7 @@ script = ExtResource("3_m2w30")
 Priority = 0
 "Follow Mode" = 0
 "Look At Mode" = 0
-"Tween Properties/Duration" = 0.6
-"Tween Properties/Transition" = 0
+"Tween Parameters" = SubResource("Resource_hml7x")
 
 [node name="TweenNameLabel" type="Label3D" parent="Tweening Example/Linear"]
 transform = Transform3D(1, 0, 0, 0, 0.695913, 0.718126, 0, -0.718126, 0.695913, -1.8, 0.5, 0)
@@ -142,9 +165,7 @@ script = ExtResource("3_m2w30")
 Priority = 0
 "Follow Mode" = 0
 "Look At Mode" = 0
-"Tween Properties/Duration" = 0.6
-"Tween Properties/Transition" = 1
-"Tween Properties/Ease" = 2
+"Tween Parameters" = SubResource("Resource_pjwwe")
 
 [node name="TweenNameLabel" type="Label3D" parent="Tweening Example/Sine"]
 transform = Transform3D(1, 0, 0, 0, 0.695913, 0.718126, 0, -0.718126, 0.695913, 1.7, 0.5, 0)
@@ -180,9 +201,7 @@ script = ExtResource("3_m2w30")
 Priority = 0
 "Follow Mode" = 0
 "Look At Mode" = 0
-"Tween Properties/Duration" = 0.3
-"Tween Properties/Transition" = 8
-"Tween Properties/Ease" = 2
+"Tween Parameters" = SubResource("Resource_ex8sv")
 
 [node name="TweenNameLabel" type="Label3D" parent="Tweening Example/Circ"]
 transform = Transform3D(1, 0, 0, 0, 0.695913, 0.718126, 0, -0.718126, 0.695913, -1.8, 0.5, 0)
@@ -218,9 +237,7 @@ script = ExtResource("3_m2w30")
 Priority = 0
 "Follow Mode" = 0
 "Look At Mode" = 0
-"Tween Properties/Duration" = 1.2
-"Tween Properties/Transition" = 10
-"Tween Properties/Ease" = 2
+"Tween Parameters" = SubResource("Resource_n4qdq")
 
 [node name="TweenNameLabel" type="Label3D" parent="Tweening Example/Back"]
 transform = Transform3D(1, 0, 0, 0, 0.695913, 0.718126, 0, -0.718126, 0.695913, 1.7, 0.5, 0)

--- a/addons/phantom_camera/examples/resources/tween/FixedCameraTween.tres
+++ b/addons/phantom_camera/examples/resources/tween/FixedCameraTween.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Resource" script_class="PhantomCameraTween" load_steps=2 format=3 uid="uid://c1v786g5agaw5"]
+
+[ext_resource type="Script" path="res://addons/phantom_camera/scripts/resources/tween_resource.gd" id="1_ptlie"]
+
+[resource]
+script = ExtResource("1_ptlie")
+duration = 0.0
+transition = 0
+ease = 2

--- a/addons/phantom_camera/examples/resources/tween/InventoryPhantomCamera2DTween.tres
+++ b/addons/phantom_camera/examples/resources/tween/InventoryPhantomCamera2DTween.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Resource" script_class="PhantomCameraTweenResource" load_steps=2 format=3 uid="uid://cllveybboaqk5"]
+
+[ext_resource type="Script" path="res://addons/phantom_camera/scripts/resources/tween_resource.gd" id="1_7yoy0"]
+
+[resource]
+script = ExtResource("1_7yoy0")
+duration = 0.6
+transition = 5
+ease = 1

--- a/addons/phantom_camera/examples/resources/tween/ItemFocusPhantomCamera2DTween.tres
+++ b/addons/phantom_camera/examples/resources/tween/ItemFocusPhantomCamera2DTween.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Resource" script_class="PhantomCameraTweenResource" load_steps=2 format=3 uid="uid://cecrnq0wnkexh"]
+
+[ext_resource type="Script" path="res://addons/phantom_camera/scripts/resources/tween_resource.gd" id="1_sq5ls"]
+
+[resource]
+script = ExtResource("1_sq5ls")
+duration = 0.6
+transition = 8
+ease = 1

--- a/addons/phantom_camera/examples/resources/tween/PlayerPhantomCamera2DTween.tres
+++ b/addons/phantom_camera/examples/resources/tween/PlayerPhantomCamera2DTween.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Resource" script_class="PhantomCameraTween" load_steps=2 format=3 uid="uid://euybd2w0bax"]
+
+[ext_resource type="Script" path="res://addons/phantom_camera/scripts/resources/tween_resource.gd" id="1_by4ei"]
+
+[resource]
+script = ExtResource("1_by4ei")
+duration = 0.6
+transition = 3
+ease = 1

--- a/addons/phantom_camera/examples/resources/tween/PlayerPhantomCamera3DTween.tres
+++ b/addons/phantom_camera/examples/resources/tween/PlayerPhantomCamera3DTween.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Resource" script_class="PhantomCameraTween" load_steps=2 format=3 uid="uid://cptfoggk2ok67"]
+
+[ext_resource type="Script" path="res://addons/phantom_camera/scripts/resources/tween_resource.gd" id="1_q5tix"]
+
+[resource]
+script = ExtResource("1_q5tix")
+duration = 0.6
+transition = 4
+ease = 2

--- a/addons/phantom_camera/examples/scripts/3D/player_controller.gd
+++ b/addons/phantom_camera/examples/scripts/3D/player_controller.gd
@@ -3,6 +3,7 @@ extends CharacterBody3D
 
 @export var SPEED = 5.0
 @export var JUMP_VELOCITY = 4.5
+@export var enable_gravity = true
 
 @onready var _camera: Camera3D = %MainCamera3D
 
@@ -50,7 +51,7 @@ func _ready() -> void:
 
 func _physics_process(delta: float) -> void:
 	# Add the gravity.
-	if not is_on_floor():
+	if enable_gravity and not is_on_floor():
 		velocity.y -= gravity * delta
 
 	# Get the input direction and handle the movement/deceleration.

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2D.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2D.gd
@@ -134,9 +134,7 @@ func _get(property: StringName):
 	if property == Constants.FOLLOW_DAMPING_NAME: 					return Properties.follow_has_damping
 	if property == Constants.FOLLOW_DAMPING_VALUE_NAME: 			return Properties.follow_damping_value
 
-	if property == Constants.TWEEN_DURATION_PROPERTY_NAME: 			return Properties.tween_duration
-	if property == Constants.TWEEN_TRANSITION_PROPERTY_NAME: 		return Properties.tween_transition
-	if property == Constants.TWEEN_EASE_PROPERTY_NAME: 				return Properties.tween_ease
+	if property == Constants.TWEEN_RESOURCE_PROPERTY_NAME: 			return Properties.tween_resource
 
 
 ###################
@@ -196,13 +194,21 @@ func get_priority() -> int:
 	return Properties.priority
 
 
+# Tween Functions
 func get_tween_duration() -> float:
-	return Properties.tween_duration
-
+	if Properties.tween_resource:
+		return Properties.tween_resource.duration
+	else:
+		return Properties.tween_resource_default.duration
 
 func get_tween_transition() -> int:
-	return Properties.tween_transition
-
+	if Properties.tween_resource:
+		return Properties.tween_resource.transition
+	else:
+		return Properties.tween_resource_default.transition
 
 func get_tween_ease() -> int:
-	return Properties.tween_ease
+	if Properties.tween_resource:
+		return Properties.tween_resource.ease
+	else:
+		return Properties.tween_resource_default.ease

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3D.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3D.gd
@@ -296,9 +296,7 @@ func _get(property: StringName):
 	##################
 	# Tween Properties
 	##################
-	if property == Constants.TWEEN_DURATION_PROPERTY_NAME: 			return Properties.tween_duration
-	if property == Constants.TWEEN_TRANSITION_PROPERTY_NAME: 		return Properties.tween_transition
-	if property == Constants.TWEEN_EASE_PROPERTY_NAME: 				return Properties.tween_ease
+	if property == Constants.TWEEN_RESOURCE_PROPERTY_NAME: 			return Properties.tween_resource
 
 
 ###################
@@ -404,17 +402,6 @@ func get_priority() -> int:
 	return Properties.priority
 
 
-# Tween Functions
-func get_tween_duration() -> float:
-	return Properties.tween_duration
-
-func get_tween_transition() -> int:
-	return Properties.tween_transition
-
-func get_tween_ease() -> int:
-	return Properties.tween_ease
-
-
 # Look At Group Functions
 func add_node_to_look_at_group(node: Node3D) -> void:
 	if not _look_at_group_nodes.has(node):
@@ -422,3 +409,24 @@ func add_node_to_look_at_group(node: Node3D) -> void:
 
 func remove_node_from_look_at_group(node: Node3D) -> void:
 	_look_at_group_nodes.erase(node)
+
+
+# Tween Functions
+func get_tween_duration() -> float:
+#	return Properties.tween_duration
+	if Properties.tween_resource:
+		return Properties.tween_resource.duration
+	else:
+		return Properties.tween_resource_default.duration
+
+func get_tween_transition() -> int:
+	if Properties.tween_resource:
+		return Properties.tween_resource.transition
+	else:
+		return Properties.tween_resource_default.transition
+
+func get_tween_ease() -> int:
+	if Properties.tween_resource:
+		return Properties.tween_resource.ease
+	else:
+		return Properties.tween_resource_default.ease

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_constants.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_constants.gd
@@ -21,10 +21,8 @@ const FOLLOW_DAMPING_NAME: StringName = FOLLOW_PARAMETERS_NAME + "Damping"
 const FOLLOW_DAMPING_VALUE_NAME: StringName = FOLLOW_PARAMETERS_NAME + "Damping Value"
 const FOLLOW_TARGET_OFFSET_PROPERTY_NAME: StringName = FOLLOW_PARAMETERS_NAME + "Target Offset"
 
-const TWEEN_CATEGORY_NAME: StringName = "Tween Properties/"
-const TWEEN_TRANSITION_PROPERTY_NAME: StringName = TWEEN_CATEGORY_NAME + "Transition"
-const TWEEN_EASE_PROPERTY_NAME: StringName = TWEEN_CATEGORY_NAME + "Ease"
-const TWEEN_DURATION_PROPERTY_NAME: StringName = TWEEN_CATEGORY_NAME + "Duration"
+# Tween Resource
+const TWEEN_RESOURCE_PROPERTY_NAME: StringName = "Tween Parameters"
 
 enum FollowMode {
 	NONE 	= 0,

--- a/addons/phantom_camera/scripts/resources/tween_resource.gd
+++ b/addons/phantom_camera/scripts/resources/tween_resource.gd
@@ -1,0 +1,13 @@
+class_name PhantomCameraTween
+extends Resource
+
+const Constants = preload("res://addons/phantom_camera/scripts/phantom_camera/phantom_camera_constants.gd")
+
+## The time it takes to tween to this property
+@export var duration: float = 1
+
+## The transition bezier type for the tween
+@export var transition: Constants.TweenTransitions = Constants.TweenTransitions.LINEAR
+
+## The ease type for the tween
+@export var ease: Constants.TweenEases = Constants.TweenEases.EASE_IN_OUT


### PR DESCRIPTION
Resolves #39 

- [Updated] Example scenes to use the new Tween Resource
- [Added] Various tween resources for reused properties
- [Replaced] 3DFollowExampleScene.tscn with 3DFollowGluedExampleScene.tscn
- [Added] Gravity toggle to player_controller.gd