### PR TITLE
Added property helper functions for PCam2D

### DIFF
--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2D.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2D.gd
@@ -124,12 +124,12 @@ func _get(property: StringName):
 	if property == FOLLOW_GROUP_ZOOM_AUTO:							return follow_group_zoom_auto
 	if property == FOLLOW_GROUP_ZOOM_MIN: 							return follow_group_zoom_min
 	if property == FOLLOW_GROUP_ZOOM_MAX: 							return follow_group_zoom_max
-	if property == FOLLOW_GROUP_ZOOM_MARGIN: 						return follow_group_zoom_margin
+	if property == FOLLOW_GROUP_ZOOM_MARGIN:						return follow_group_zoom_margin
 	if property == Constants.FOLLOW_TARGET_OFFSET_PROPERTY_NAME:	return Properties.follow_target_offset_2D
 	if property == Constants.FOLLOW_DAMPING_NAME: 					return Properties.follow_has_damping
 	if property == Constants.FOLLOW_DAMPING_VALUE_NAME: 			return Properties.follow_damping_value
 
-	if property == Constants.TWEEN_RESOURCE_PROPERTY_NAME: 			return Properties.tween_resource
+	if property == Constants.TWEEN_RESOURCE_PROPERTY_NAME:			return Properties.tween_resource
 
 	if property == Constants.INACTIVE_UPDATE_MODE_PROPERTY_NAME:	return Properties.inactive_update_mode
 	if property == Constants.TWEEN_ONLOAD_NAME: 					return Properties.tween_onload
@@ -175,18 +175,22 @@ func _physics_process(delta: float) -> void:
 					set_global_position(Properties.follow_group_nodes_2D[0].get_position())
 				else:
 					var rect: Rect2 = Rect2(Properties.follow_group_nodes_2D[0].get_global_position(), Vector2.ZERO)
-					var screen_size: Vector2 = get_viewport_rect().size
 					for node in Properties.follow_group_nodes_2D:
 						rect = rect.expand(node.get_global_position())
-						rect = rect.grow_individual(
-							follow_group_zoom_margin.x,
-							follow_group_zoom_margin.y,
-							follow_group_zoom_margin.z,
-							follow_group_zoom_margin.w)
-					if rect.size.x > rect.size.y * screen_size.aspect():
-						Properties.zoom = clamp(screen_size.x / rect.size.x, follow_group_zoom_min, follow_group_zoom_max) * Vector2.ONE
-					else:
-						Properties.zoom = clamp(screen_size.y / rect.size.y, follow_group_zoom_min, follow_group_zoom_max) * Vector2.ONE
+						if follow_group_zoom_auto:
+							rect = rect.grow_individual(
+								follow_group_zoom_margin.x,
+								follow_group_zoom_margin.y,
+								follow_group_zoom_margin.z,
+								follow_group_zoom_margin.w)
+
+					if follow_group_zoom_auto:
+						var screen_size: Vector2 = get_viewport_rect().size
+						if rect.size.x > rect.size.y * screen_size.aspect():
+							Properties.zoom = clamp(screen_size.x / rect.size.x, follow_group_zoom_min, follow_group_zoom_max) * Vector2.ONE
+						else:
+							Properties.zoom = clamp(screen_size.y / rect.size.y, follow_group_zoom_min, follow_group_zoom_max) * Vector2.ONE
+
 					set_global_position(rect.get_center())
 		Constants.FollowMode.PATH:
 				if Properties.follow_target_node and Properties.follow_path_node:
@@ -200,24 +204,144 @@ func _physics_process(delta: float) -> void:
 ##################
 # Public Functions
 ##################
+func get_pcam_host_owner() -> PhantomCameraHost:
+	return Properties.pcam_host_owner
+
+
+func set_zoom(value: Vector2) -> void:
+	Properties.zoom = value
+func get_zoom() -> Vector2:
+	return Properties.zoom
+
+
 func set_priority(value: int) -> void:
 	Properties.set_priority(value, self)
 func get_priority() -> int:
 	return Properties.priority
 
 
+func set_tween_duration(value: float) -> void:
+	if Properties.tween_resource:
+		Properties.tween_resource_default.duration = value
+		Properties.tween_resource_default.transition = Properties.tween_resource.transition
+		Properties.tween_resource_default.ease = Properties.tween_resource.ease
+		Properties.tween_resource = null # Clears resource from PCam instance
+	else:
+		Properties.tween_resource_default.duration = value
 func get_tween_duration() -> float:
 	if Properties.tween_resource:
 		return Properties.tween_resource.duration
 	else:
 		return Properties.tween_resource_default.duration
+
+func set_tween_transition(value: Constants.TweenTransitions) -> void:
+	if Properties.tween_resource:
+		Properties.tween_resource_default.duration = Properties.tween_resource.duration
+		Properties.tween_resource_default.transition = value
+		Properties.tween_resource_default.ease = Properties.tween_resource.ease
+		Properties.tween_resource = null # Clears resource from PCam instance
+	else:
+		Properties.tween_resource_default.transition = value
 func get_tween_transition() -> int:
 	if Properties.tween_resource:
 		return Properties.tween_resource.transition
 	else:
 		return Properties.tween_resource_default.transition
+
+func set_tween_ease(value: Constants.TweenEases) -> void:
+	if Properties.tween_resource:
+		Properties.tween_resource_default.duration = Properties.tween_resource.duration
+		Properties.tween_resource_default.transition = Properties.tween_resource.ease
+		Properties.tween_resource_default.ease = value
+		Properties.tween_resource = null # Clears resource from PCam instance
+	else:
+		Properties.tween_resource_default.ease = value
 func get_tween_ease() -> int:
 	if Properties.tween_resource:
 		return Properties.tween_resource.ease
 	else:
 		return Properties.tween_resource_default.ease
+
+
+func is_active() -> bool:
+	return Properties.is_active
+
+
+func set_tween_on_load(value: bool) -> void:
+	Properties.tween_onload = value
+func is_tween_on_load() -> bool:
+	return Properties.tween_onload
+
+
+func set_follow_target_node(value: Node2D) -> void:
+	Properties.follow_target_node = value
+func get_follow_target_node():
+	if Properties.follow_target_node:
+		return Properties.follow_target_node
+	else:
+		printerr("No Follow Target Node assigned")
+
+
+func set_follow_path(value: Path2D) -> void:
+	Properties.follow_path_node = value
+func get_follow_path():
+	if Properties.follow_path_node:
+		return Properties.follow_path_node
+	else:
+		printerr("No Follow Path assigned")
+
+
+func get_follow_mode() -> String:
+	return Constants.FollowMode.keys()[Properties.follow_mode].capitalize()
+# Note: Setting Follow Mode purposely not added. A separate PCam should be used instead.
+
+
+func set_follow_target_offset(value: Vector2) -> void:
+	Properties.follow_target_offset_2D = value
+func get_follow_target_offset() -> Vector2:
+	return Properties.follow_target_offset_2D
+
+
+func set_follow_has_damping(value: bool) -> void:
+	Properties.follow_has_damping = value
+func get_follow_has_damping() -> bool:
+	return Properties.follow_has_damping
+	
+func set_follow_damping_value(value: float) -> void:
+	Properties.follow_damping_value = value
+func get_follow_damping_value() -> float:
+	return Properties.follow_damping_value
+
+
+func get_follow_group_nodes_2D() -> Array[Node2D]:
+	return Properties.follow_group_nodes_2D
+func append_follow_group_nodes_2D(value: Node2D) -> void:
+	Properties.follow_group_nodes_2D.append(value)
+func append_array_follow_group_nodes_2D(value: Array[Node2D]) -> void:
+	Properties.follow_group_nodes_2D.append_array(value)
+func erase_follow_group_nodes_2D(value: Node2D) -> void:
+	Properties.follow_group_nodes_2D.erase(value)
+
+func set_auto_zoom(value: bool) -> void:
+	follow_group_zoom_auto = value
+func get_auto_zoom() -> bool:
+	return follow_group_zoom_auto
+
+func set_min_zoom(value: float) -> void:
+	follow_group_zoom_min = value
+func get_min_zoom() -> float:
+	return follow_group_zoom_min
+
+func set_max_zoom(value: float) -> void:
+	follow_group_zoom_max = value
+func get_max_zoom() -> float:
+	return follow_group_zoom_max
+
+func set_zoom_margin(value: Vector4) -> void:
+	follow_group_zoom_margin = value
+func get_zoom_margin() -> Vector4:
+	return follow_group_zoom_margin
+
+
+func get_inactive_update_mode() -> bool:
+	return Properties.inactive_update_mode

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2D.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2D.gd
@@ -313,13 +313,13 @@ func get_follow_damping_value() -> float:
 	return Properties.follow_damping_value
 
 
-func get_follow_group_nodes_2D() -> Array[Node2D]:
+func get_follow_group_nodes() -> Array[Node2D]:
 	return Properties.follow_group_nodes_2D
-func append_follow_group_nodes_2D(value: Node2D) -> void:
+func append_follow_group_nodes(value: Node2D) -> void:
 	Properties.follow_group_nodes_2D.append(value)
-func append_array_follow_group_nodes_2D(value: Array[Node2D]) -> void:
+func append_array_follow_group_nodes(value: Array[Node2D]) -> void:
 	Properties.follow_group_nodes_2D.append_array(value)
-func erase_follow_group_nodes_2D(value: Node2D) -> void:
+func erase_follow_group_nodes(value: Node2D) -> void:
 	Properties.follow_group_nodes_2D.erase(value)
 
 func set_auto_zoom(value: bool) -> void:

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2D.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2D.gd
@@ -150,6 +150,7 @@ func _exit_tree() -> void:
 	Properties.pcam_exit_tree(self)
 
 func _physics_process(delta: float) -> void:
+#	print(follow_group_zoom_margin)
 	if not Properties.is_active:
 		match Properties.inactive_update_mode:
 			Constants.InactiveUpdateMode.NEVER:
@@ -178,19 +179,21 @@ func _physics_process(delta: float) -> void:
 					for node in Properties.follow_group_nodes_2D:
 						rect = rect.expand(node.get_global_position())
 						if follow_group_zoom_auto:
+#							print(follow_group_zoom_margin.x)
 							rect = rect.grow_individual(
 								follow_group_zoom_margin.x,
 								follow_group_zoom_margin.y,
 								follow_group_zoom_margin.z,
 								follow_group_zoom_margin.w)
-
+#						else:
+#							rect = rect.grow_individual(-80, 0, 0, 0)
 					if follow_group_zoom_auto:
 						var screen_size: Vector2 = get_viewport_rect().size
 						if rect.size.x > rect.size.y * screen_size.aspect():
 							Properties.zoom = clamp(screen_size.x / rect.size.x, follow_group_zoom_min, follow_group_zoom_max) * Vector2.ONE
 						else:
 							Properties.zoom = clamp(screen_size.y / rect.size.y, follow_group_zoom_min, follow_group_zoom_max) * Vector2.ONE
-
+#					print(Properties.zoom)
 					set_global_position(rect.get_center())
 		Constants.FollowMode.PATH:
 				if Properties.follow_target_node and Properties.follow_path_node:
@@ -281,7 +284,6 @@ func get_follow_target_node():
 	else:
 		printerr("No Follow Target Node assigned")
 
-
 func set_follow_path(value: Path2D) -> void:
 	Properties.follow_path_node = value
 func get_follow_path():
@@ -290,17 +292,14 @@ func get_follow_path():
 	else:
 		printerr("No Follow Path assigned")
 
-
 func get_follow_mode() -> String:
 	return Constants.FollowMode.keys()[Properties.follow_mode].capitalize()
 # Note: Setting Follow Mode purposely not added. A separate PCam should be used instead.
-
 
 func set_follow_target_offset(value: Vector2) -> void:
 	Properties.follow_target_offset_2D = value
 func get_follow_target_offset() -> Vector2:
 	return Properties.follow_target_offset_2D
-
 
 func set_follow_has_damping(value: bool) -> void:
 	Properties.follow_has_damping = value
@@ -313,14 +312,21 @@ func get_follow_damping_value() -> float:
 	return Properties.follow_damping_value
 
 
+func append_follow_group_node(value: Node2D) -> void:
+	if not Properties.follow_group_nodes_2D.has(value):
+		Properties.follow_group_nodes_2D.append(value)
+	else:
+		printerr(value, " is already part of Follow Group")
+func append_array_follow_group_nodes(value: Array[Node2D]) -> void:
+	for val in value:
+		if not Properties.follow_group_nodes_2D.has(val):
+			Properties.follow_group_nodes_2D.append(val)
+		else:
+			printerr(val, " is already part of Follow Group")
+func erase_follow_group_node(value: Node2D) -> void:
+	Properties.follow_group_nodes_2D.erase(value)
 func get_follow_group_nodes() -> Array[Node2D]:
 	return Properties.follow_group_nodes_2D
-func append_follow_group_nodes(value: Node2D) -> void:
-	Properties.follow_group_nodes_2D.append(value)
-func append_array_follow_group_nodes(value: Array[Node2D]) -> void:
-	Properties.follow_group_nodes_2D.append_array(value)
-func erase_follow_group_nodes(value: Node2D) -> void:
-	Properties.follow_group_nodes_2D.erase(value)
 
 func set_auto_zoom(value: bool) -> void:
 	follow_group_zoom_auto = value
@@ -343,5 +349,5 @@ func get_zoom_margin() -> Vector4:
 	return follow_group_zoom_margin
 
 
-func get_inactive_update_mode() -> bool:
-	return Properties.inactive_update_mode
+func get_inactive_update_mode() -> String:
+	return Constants.InactiveUpdateMode.keys()[Properties.inactive_update_mode].capitalize()

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3D.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3D.gd
@@ -474,6 +474,23 @@ func set_follow_distance(value: float) -> void:
 func get_follow_distance() -> float:
 	return follow_distance
 
+
+func append_follow_group_node(value: Node3D) -> void:
+	if not Properties.follow_group_nodes_3D.has(value):
+		Properties.follow_group_nodes_3D.append(value)
+	else:
+		printerr(value, " is already part of Follow Group")
+func append_array_follow_group_nodes(value: Array[Node3D]) -> void:
+	for val in value:
+		if not Properties.follow_group_nodes_3D.has(val):
+			Properties.follow_group_nodes_3D.append(val)
+		else:
+			printerr(value, " is already part of Follow Group")
+func erase_follow_group_node(value: Node3D) -> void:
+	Properties.follow_group_nodes_3D.erase(value)
+func get_follow_group_nodes() -> Array[Node3D]:
+	return Properties.follow_group_nodes_3D
+
 func set_auto_follow_distance(value: bool) -> void:
 	_follow_group_distance_auto = value
 func get_auto_follow_distance() -> bool:
@@ -493,22 +510,6 @@ func set_auto_follow_distance_divisor(value: float) -> void:
 	_follow_group_distance_auto_divisor = value
 func get_auto_follow_distance_divisor() -> float:
 	return _follow_group_distance_auto_divisor
-
-func get_follow_group_nodes() -> Array[Node3D]:
-	return Properties.follow_group_nodes_3D
-func append_follow_group_nodes(value: Node3D) -> void:
-	if not Properties.follow_group_nodes_3D.has(value):
-		Properties.follow_group_nodes_3D.append(value)
-	else:
-		printerr(value, "is already part of Follow Group")
-func append_array_follow_group_nodes(value: Array[Node3D]) -> void:
-	for val in value:
-		if not Properties.follow_group_nodes_3D.has(val):
-			Properties.follow_group_nodes_3D.append(val)
-		else:
-			printerr(value, "is already part of Follow Group")
-func erase_follow_group_nodes(value: Node3D) -> void:
-	Properties.follow_group_nodes_3D.erase(value)
 
 
 func get_look_at_mode() -> String:

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3D.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3D.gd
@@ -369,32 +369,183 @@ func assign_pcam_host() -> void:
 	Properties.assign_pcam_host(self)
 
 
+func get_pcam_host_owner() -> PhantomCameraHost:
+	return Properties.pcam_host_owner
+
+
 func set_priority(value: int) -> void:
 	Properties.set_priority(value, self)
 func get_priority() -> int:
 	return Properties.priority
 
 
-func add_node_to_look_at_group(node: Node3D) -> void:
-	if not _look_at_group_nodes.has(node):
-		_look_at_group_nodes.append(node)
-func remove_node_from_look_at_group(node: Node3D) -> void:
-	_look_at_group_nodes.erase(node)
-
-
+func set_tween_duration(value: float) -> void:
+	if Properties.tween_resource:
+		Properties.tween_resource_default.duration = value
+		Properties.tween_resource_default.transition = Properties.tween_resource.transition
+		Properties.tween_resource_default.ease = Properties.tween_resource.ease
+		Properties.tween_resource = null # Clears resource from PCam instance
+	else:
+		Properties.tween_resource_default.duration = value
 func get_tween_duration() -> float:
-#	return Properties.tween_duration
 	if Properties.tween_resource:
 		return Properties.tween_resource.duration
 	else:
 		return Properties.tween_resource_default.duration
+
+func set_tween_transition(value: Constants.TweenTransitions) -> void:
+	if Properties.tween_resource:
+		Properties.tween_resource_default.duration = Properties.tween_resource.duration
+		Properties.tween_resource_default.transition = value
+		Properties.tween_resource_default.ease = Properties.tween_resource.ease
+		Properties.tween_resource = null # Clears resource from PCam instance
+	else:
+		Properties.tween_resource_default.transition = value
 func get_tween_transition() -> int:
 	if Properties.tween_resource:
 		return Properties.tween_resource.transition
 	else:
 		return Properties.tween_resource_default.transition
+
+func set_tween_ease(value: Constants.TweenEases) -> void:
+	if Properties.tween_resource:
+		Properties.tween_resource_default.duration = Properties.tween_resource.duration
+		Properties.tween_resource_default.transition = Properties.tween_resource.ease
+		Properties.tween_resource_default.ease = value
+		Properties.tween_resource = null # Clears resource from PCam instance
+	else:
+		Properties.tween_resource_default.ease = value
 func get_tween_ease() -> int:
 	if Properties.tween_resource:
 		return Properties.tween_resource.ease
 	else:
 		return Properties.tween_resource_default.ease
+
+
+func is_active() -> bool:
+	return Properties.is_active
+
+
+func set_tween_on_load(value: bool) -> void:
+	Properties.tween_onload = value
+func is_tween_on_load() -> bool:
+	return Properties.tween_onload
+
+
+func set_follow_target_node(value: Node3D) -> void:
+	Properties.follow_target_node = value
+func get_follow_target_node():
+	if Properties.follow_target_node:
+		return Properties.follow_target_node
+	else:
+		printerr("No Follow Target Node assigned")
+
+
+func set_follow_path(value: Path3D) -> void:
+	Properties.follow_path_node = value
+func get_follow_path():
+	if Properties.follow_path_node:
+		return Properties.follow_path_node
+	else:
+		printerr("No Follow Path assigned")
+
+
+func get_follow_mode() -> String:
+	return Constants.FollowMode.keys()[Properties.follow_mode].capitalize()
+# Note: Setting Follow Mode purposely not added. A separate PCam should be used instead.
+
+func set_follow_target_offset(value: Vector3) -> void:
+	Properties.follow_target_offset_3D = value
+func get_follow_target_offset() -> Vector3:
+	return Properties.follow_target_offset_3D
+
+func set_follow_has_damping(value: bool) -> void:
+	Properties.follow_has_damping = value
+func get_follow_has_damping() -> bool:
+	return Properties.follow_has_damping
+	
+func set_follow_damping_value(value: float) -> void:
+	Properties.follow_damping_value = value
+func get_follow_damping_value() -> float:
+	return Properties.follow_damping_value
+
+func set_follow_distance(value: float) -> void:
+	follow_distance = value
+func get_follow_distance() -> float:
+	return follow_distance
+
+func set_auto_follow_distance(value: bool) -> void:
+	_follow_group_distance_auto = value
+func get_auto_follow_distance() -> bool:
+	return _follow_group_distance_auto 
+
+func set_min_auto_follow_distance(value: float) -> void:
+	_follow_group_distance_auto_min = value
+func get_min_auto_follow_distance() -> float:
+	return _follow_group_distance_auto_min
+
+func set_max_auto_follow_distance(value: float) -> void:
+	_follow_group_distance_auto_max = value
+func get_max_auto_follow_distance() -> float:
+	return _follow_group_distance_auto_max
+	
+func set_auto_follow_distance_divisor(value: float) -> void:
+	_follow_group_distance_auto_divisor = value
+func get_auto_follow_distance_divisor() -> float:
+	return _follow_group_distance_auto_divisor
+
+func get_follow_group_nodes() -> Array[Node3D]:
+	return Properties.follow_group_nodes_3D
+func append_follow_group_nodes(value: Node3D) -> void:
+	if not Properties.follow_group_nodes_3D.has(value):
+		Properties.follow_group_nodes_3D.append(value)
+	else:
+		printerr(value, "is already part of Follow Group")
+func append_array_follow_group_nodes(value: Array[Node3D]) -> void:
+	for val in value:
+		if not Properties.follow_group_nodes_3D.has(val):
+			Properties.follow_group_nodes_3D.append(val)
+		else:
+			printerr(value, "is already part of Follow Group")
+func erase_follow_group_nodes(value: Node3D) -> void:
+	Properties.follow_group_nodes_3D.erase(value)
+
+
+func get_look_at_mode() -> String:
+	return LookAtMode.keys()[look_at_mode].capitalize()
+# Note: Setting Follow Mode purposely not added. A separate PCam should be used instead.
+
+func set_look_at_target(value: Node3D) -> void:
+	_look_at_target_node = value
+	_should_look_at = true
+	_has_look_at_target = true
+func get_look_at_target():
+	if _look_at_target_node:
+		return _look_at_target_node
+	else:
+		printerr("No Look At target node assigned")
+
+func set_look_at_target_offset(value: Vector3) -> void:
+	look_at_target_offset = value
+func get_look_at_target_offset() -> Vector3:
+	return look_at_target_offset
+
+func get_look_at_group_nodes() -> Array[Node3D]:
+	return _look_at_group_nodes
+func append_look_at_group_node(value: Node3D) -> void:
+	if not _look_at_group_nodes.has(value):
+		_look_at_group_nodes.append(value)
+	else:
+		printerr(value, " is already part of Look At Group")
+func append_array_look_at_group_nodes(value: Array[Node3D]) -> void:
+	for val in value:
+		if not _look_at_group_nodes.has(val):
+			_look_at_group_nodes.append(val)
+		else:
+			printerr(val, " is already part of Look At Group")
+func erase_look_at_group_node(value: Node3D) -> void:
+	_look_at_group_nodes.erase(value)
+
+
+func get_inactive_update_mode() -> String:
+	return Constants.InactiveUpdateMode.keys()[Properties.inactive_update_mode].capitalize()


### PR DESCRIPTION
Solves #102 

#### Property Setters
- `set_phantom_camera_host(value: PhantomCameraHost) -> void`
  - Support for to be added as part of #63.
- [x] `set_priority(value: int) -> void` (Already added)
  - Changes the `PCam's` current priority.
- [x] `set_tween_duration(value: float) -> void`
  - Returns the duration of the `PCam's` transition.
- [x] `set_tween_transition(value: int) -> void`
  - Returns the transition type.
- [x] `set_tween_ease(value: int) -> void`
  - Returns the ease type.
- ~`set_is_active(value: bool) -> void`~
  - Should only be changed by PCamHost based on its `priority`.
- [x] `set_tween_on_load(value: bool) -> void`
  - Changes whether if a tween is meant to trigger its transition upon being loaded.
- [x] `set_follow_target_node(value: Node2 / Node3D) ->`
  - Changes the Node2D / Node3D target.
- [x] `set_follow_path(value: Path2D / Path3D) -> void`
  - Changes the followed `PathNode`.
- ~`set_follow_mode(value: int) -> void`~
  - Shouldn't be modified during runtime. Switching to another `PCam` should be done instead.
- [x] `set_follow_target_offset(value: Vector2 / Vector3) -> `
  - Changes the `Vector2` / `Vector3` target offset value.
- [x] `set_follow_has_damping(bool) -> void`
  - Changes the follow damping state.
- [x] `set_follow_damping_value(float) -> void`
  - Changes the follow damping value.
- [x] `append_follow_group_nodes(value: Node2D / Node3D) -> void`
  - Appends a new target to a `Follow Group` `PCam`.
- [x] `append_array_follow_group_nodes_2D(value: Array[Node2D / Node 3D]) -> void`
  - Appends an array of Nodes to a `Follow Group` `PCam`.
- [x] `erase_follow_group_nodes(value: Array[Node2D / Node3D]) -> void`
  -  Erases a specified target from a `Follow Group` `PCam`.
- [x] `set_inactive_update_mode(value: int) -> void`
  - Changes the inactive update mode.

*2D*
- [x] `set_zoom(value: Vector2) -> void`
  - Changes the `zoom` level. This will have no effect if the `PCam2D` is set to `Follow Group` *and* `Auto Zoom`.
- [x] `set_auto_zoom(value: bool) -> void`
  - Enable or disable `auto zoom` for `Group Follow` mode.
- [x] `set_min_zoom(value: float) -> void`
  - Changes the current `min zoom` level for `Follow Group` mode.
- [x] `set_max_zoom(value: float) -> void`
  - Changes the current `max zoom` level for `Follow Group` mode.
- [x] `set_zoom_margin(value: Vector4) -> void`
  - Changes the `zoom margin` for `Group Follow` mode.

*3D*
- [x] `set_follow_distance(value: float) -> void`
  - Changes the distance value.
- [x] `set_auto_follow_distance(value: bool) -> void`
  - Enables or disables the `auto follow distance` behaviour.
- [x] `set_min_follow_distance(value: float) -> void
  - Changes the `min follow distance`.
- [x] `set_max_follow_distance(value: float) -> void`
  - Changes the `max follow distance`.
- [x] `set_auto_follow_distance_divisor(value: float) -> void`
  - Changes the divisor value for `auto follow distance`.
- [x] `set_look_at_target(value: Node3D) -> void`
  - Changes or applies a `look at` target.
- [x] `set_look_at_target_offset(value: Vector3) -> void`
  - Changes the `look at` `offset`.
- [x] `append_look_at_group_nodes(value: Node3D) -> void`
  - Adds a new target to the look at group.
- [x] `erase_look_at_group_nodes(value: Node3D) -> void`
  - Removes a `Node3D` from `look at group`.

#### Property Getters
- [x] `get_phantom_camera_host() -> PhantomCameraHost`
  - Returns the` PCamHost` the `PCam` is assigned to.
- [x] `get_priority() -> int` (Already added)
  - Returns the `PCam's` current priority.
- [x] `get_tween_duration() -> float`
  - Returns the duration of the `PCam's` transition.
- [x] `get_tween_transition() -> int`
  - Returns the transition type.
- [x] `get_tween_ease() -> int`
  - Returns the ease type
- [x] `is_active() -> bool`
  - Returns the active state of a `PCam`.
- [x] `is_tween_on_load() -> bool`
  - Returns whether if a tween is meant to trigger its transition upon being loaded.
- [x] `get_follow_target_node()`
  - May return either a `Node2D`/ `Node3D` or an error statement.
- [x] `get_follow_path()`
  - May return either a `Node2D` / `Node3D` or an error statement.
- [x] `get_follow_mode() -> String`
  - Returns the name of the `follow mode`, as opposed to an `int`, to simply readability.
- [x] `get_follow_target_offset() -> Vector2 / Vector3`
  - Returns the `Vector2` / `Vector3` target offset value.
- [x] `get_follow_has_damping() -> bool`
  - Returns the follow damping state.
- [x] `get_follow_damping_value() -> float`
  - Returns the follow damping value.
- [x] `get_follow_group_nodes() -> Array[Node2D / Node3D]`
  - Returns the list of targets assigned to a `Follow Group` `PCam`.
- [x] `get_inactive_update_mode() -> int`
  - Returns the inactive update mode.

*2D*
- [x] `get_zoom() -> Vector2`
  - Returns the `zoom` level.
- [x] `get_auto_zoom() -> bool`
  - Returns `auto zoom`'s state for `Group Follow` mode.
- [x] `get_min_zoom() -> float`
  - Returns the current `min zoom` level for `Group Follow` mode.
- [x] `get_max_zoom() -> float`
  - Returns the current `max zoom` level for `Group Follow` mode.
- [x] `get_zoom_margin() -> Vector4`
  - Returns the `zoom margin` for `Group Follow`.

*3D*
- [x] `get_look_at_mode() -> String`
  - Returns the name of the `look at` type.
- [x] `get_look_at_target() -> Node3D`
  - Returns the `look at` target.
- [x] `get_follow_distance() -> float`
  - Returns the distance value.
- [x] `get_auto_follow_distance() -> bool`
  - Returns the `auto follow distance`.
- [x] `get_min_follow_distance() -> float`
  - Returns the `min follow distance`.
- [x] `get_max_follow_distance() -> float`
  - Returns the `max follow distance`.
- [x] `get_auto_follow_distance_divisor() -> float`
  - Returns the divisor value for `auto follow distance`.