### PR TITLE
Set spring arm to "top level" when in Third Person

### DIFF
--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3D.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3D.gd
@@ -497,6 +497,7 @@ func _ready():
 		if not Engine.is_editor_hint():
 			if not is_instance_valid(_follow_spring_arm_node):
 				_follow_spring_arm_node = SpringArm3D.new()
+				_follow_spring_arm_node.top_level = true
 				get_parent().add_child.call_deferred(_follow_spring_arm_node)
 	if Properties.follow_mode == Constants.FollowMode.FRAMED:
 		if not Engine.is_editor_hint():


### PR DESCRIPTION
Set `_follow_spring_arm_node.top_level = true` when creating it and adding it to the parent node (which is the parent node of the PhantomCamera3D at this point). This allows you to add the PhantomCamera3D to the moving character instance and still have it follow the character without the the spring arm inheriting the character's position. The PhantomCamera3D will be reparanted to the spring arm later on, so the PhantomCamera3D shouldn't be top_level.

This is just a slight qol improvement I think that made sense for my use case, but also might be helpful for others trying to do something similar.