### PR TITLE
Mouse Offset - Simple/Glued Follow Mode

### DIFF
--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
@@ -419,6 +419,9 @@ func _validate_property(property: Dictionary) -> void:
 	if property.name == "follow_damping_value" and not follow_damping:
 		property.usage = PROPERTY_USAGE_NO_EDITOR
 	
+	if property.name == "mouse_offset" and (follow_mode != FollowMode.SIMPLE and follow_mode != FollowMode.GLUED):
+		property.usage = PROPERTY_USAGE_NO_EDITOR
+	
 	if property.name == "mouse_offset_value" and not mouse_offset:
 		property.usage = PROPERTY_USAGE_NO_EDITOR
 
@@ -513,7 +516,10 @@ func _process(delta: float) -> void:
 	match follow_mode:
 		FollowMode.GLUED:
 			if follow_target:
-				_interpolate_position(follow_target.global_position)
+				if mouse_offset:
+					_interpolate_position(_target_position_with_mouse_offset())
+				else:
+					_interpolate_position(follow_target.global_position)
 		FollowMode.SIMPLE:
 			if follow_target:
 				if mouse_offset:

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
@@ -215,7 +215,7 @@ var _has_tweened: bool = false
 
 @export_group("Follow Parameters")
 
-## Applies an offset to the [member follow_target] position
+## Applies an offset to the [member follow_target]'s position
 ## based on mouse position.
 @export var mouse_offset: bool = false:
 	set = set_mouse_offset,
@@ -227,8 +227,8 @@ var _has_tweened: bool = false
 # the code base.
 const mouse_offset_min: float = 1.0
 const mouse_offset_max: float = 10.0
-## Defines the mouse offset amount.
-## [b]Higher value[/b] = less offset to mouse position
+## Defines the mouse offset amount. [br] [br]
+## [b]Higher value[/b] = less offset to mouse position [br]
 ## [b]Lower value[/b] = more offset to mouse position
 @export_range(mouse_offset_min, mouse_offset_max) var mouse_offset_value: float = mouse_offset_max:
 	set = set_mouse_offset_value,


### PR DESCRIPTION
# Mouse Offset - Simple/Glued Follow Mode
Hello everyone!

While testing the Phantom Camera plugin for a 2D game with shooting mechanics, I noticed that there isn't a simple way to add an offset to the Camera based on the mouse's position.

Hence, i've added two new properties to the Follow Parameters, particularly when the Follow Mode is set to either Simple or Glued, and the Follow Target is the main Player: a "Mouse Offset" property, and a "Mouse Offset Value" property.

<img width="312" alt="Screenshot 2024-04-28 at 00 48 02" src="https://github.com/ramokz/phantom-camera/assets/65407819/74686ca6-0ac9-44fd-9bac-65b5ec80a1e5">


## Mouse Offset Property
This property is a boolean, and is used to enable or disable the offset to the mouse's position.

## Mouse Offset Value Property
This property is a float, limited within a range of 1 to 10, mapped to values that affect the offset strength in a linear way.
Higher values increase how far the camera will offset towards the mouse position, whilst lower values will "tug" the camera closer to the Follow Target.

## Showcase
Below is a video demonstrating how the property behaves with different values.


https://github.com/ramokz/phantom-camera/assets/65407819/5ea61303-3dea-47f4-84ec-9f4ffe955938


## Notes
If the pull request is to be accepted, we still need to adjust the README and the website's documentation to hold the new information.