### PR TITLE
Fix incorrect return type cast

### DIFF
--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
@@ -601,7 +601,7 @@ func _smooth_damp(target_axis: float, self_axis: float, index: int, current_velo
 		return output
 
 
-func _set_limit_clamp_position(value: Vector2) -> Vector2i:
+func _set_limit_clamp_position(value: Vector2) -> Vector2:
 	var camera_frame_rect_size: Vector2 = _camera_frame_rect().size
 	value.x = clampf(value.x, _limit_sides.x + camera_frame_rect_size.x / 2, _limit_sides.z - camera_frame_rect_size.x / 2)
 	value.y = clampf(value.y, _limit_sides.y + camera_frame_rect_size.y / 2, _limit_sides.w - camera_frame_rect_size.y / 2)


### PR DESCRIPTION
Currently, `_set_limit_clamp_position()` returns a `Vector2i` when a `limit target` is applied, resulting in `target_position` always being truncated to an integer. This, without any `follow_damping`, results in the truncated `target_position` propagating to the camera's `global_position` on line 577, possibly causing misalignment between the camera and the node it's following, which can be at float x and y values.

This pr simply changes the return type to `Vector2`, leaving any logic intact.