### PR TITLE
Fixed auto_follow_distance

### DIFF
--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -582,7 +582,7 @@ func _process(delta: float) -> void:
 						var distance: float
 						if auto_follow_distance:
 							distance = lerp(auto_follow_distance_min, auto_follow_distance_max, bounds.get_longest_axis_size() / auto_follow_distance_divisor)
-							distance = clamp(follow_distance, auto_follow_distance_min, auto_follow_distance_max)
+							distance = clamp(distance, auto_follow_distance_min, auto_follow_distance_max)
 						else:
 							distance = follow_distance
 

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -581,8 +581,8 @@ func _process(delta: float) -> void:
 
 						var distance: float
 						if auto_follow_distance:
-							follow_distance = lerp(auto_follow_distance_min, auto_follow_distance_max, bounds.get_longest_axis_size() / auto_follow_distance_divisor)
-							follow_distance = clamp(follow_distance, auto_follow_distance_min, auto_follow_distance_max)
+							distance = lerp(auto_follow_distance_min, auto_follow_distance_max, bounds.get_longest_axis_size() / auto_follow_distance_divisor)
+							distance = clamp(follow_distance, auto_follow_distance_min, auto_follow_distance_max)
 						else:
 							distance = follow_distance
 


### PR DESCRIPTION
I was following the v7.0 branch.  I saw it got merged into master so I synced my fork with master.  I noticed there was a large refactor before merging in and it appears the correct assignment of "distance" was replaced with an incorrect assignment of "follow_distance".  Fortunately I have the old v7.0 branch cached on my fork.  You can see it here: https://github.com/Lange-Studios/phantom-camera/blob/dc3961faab3bdbd3d04790db49091d7601c93dfc/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3D.gd#L580

Also, you can test the example follow group and see that auto follow distance is broken.

Thanks for the awesome asset btw!  This was a simple fix :)