### PR TITLE
2D Follow Physics Interpolation

### DIFF
--- a/addons/phantom_camera/examples/scripts/3D/player_controller.gd
+++ b/addons/phantom_camera/examples/scripts/3D/player_controller.gd
@@ -48,14 +48,14 @@ func _ready() -> void:
 	for input in InputMovementDic:
 		var key_val = InputMovementDic[input].get(KEY_STRINGNAME)
 		var action_val = InputMovementDic[input].get(ACTION_STRINGNAME)
-		
+
 		_camera = owner.get_node("%MainCamera3D")
 
 		var movement_input = InputEventKey.new()
 		movement_input.physical_keycode = key_val
 		InputMap.add_action(action_val)
 		InputMap.action_add_event(action_val, movement_input)
-		
+
 		_player_visual.top_level = true
 
 

--- a/addons/phantom_camera/plugin.gd
+++ b/addons/phantom_camera/plugin.gd
@@ -62,6 +62,11 @@ func _enter_tree() -> void:
 		ProjectSettings.set_setting(updater_constants.setting_updater_notify_release, true)
 	ProjectSettings.set_initial_value(updater_constants.setting_updater_notify_release, true)
 
+	## Enables or disable
+	if not ProjectSettings.has_setting("phantom_camera/tips/show_jitter_tips"):
+		ProjectSettings.set_setting("phantom_camera/tips/show_jitter_tips", true)
+	ProjectSettings.set_initial_value("phantom_camera/tips/show_jitter_tips", true)
+
 func btn_toggled(toggled_on: bool):
 	if toggled_on:
 		editor_panel_instance.viewfinder.viewfinder_visible = true

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
@@ -581,6 +581,7 @@ func _follow_logic(delta: float) -> void:
 							follow_position = target_position
 					else:
 						_follow_framed_offset = global_position - _target_position_with_offset()
+						return
 				else:
 					follow_position = _target_position_with_offset()
 

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
@@ -140,7 +140,7 @@ var pcam_host_owner: PhantomCameraHost = null:
 	get = get_follow_target
 var _should_follow: bool = false
 var _follow_framed_offset: Vector2 = Vector2.ZERO
-var _is_physics_node: bool = false
+var _follow_target_physics_based: bool = false
 
 ### Defines the targets that the [param PhantomCamera2D] should be following.
 @export var follow_targets: Array[Node2D] = []:
@@ -387,14 +387,19 @@ func _validate_property(property: Dictionary) -> void:
 	####################
 	## Follow Parameters
 	####################
-	elif property.name == "follow_offset":
-		if follow_mode == FollowMode.GLUED or \
-		follow_mode == FollowMode.NONE:
-			property.usage = PROPERTY_USAGE_NO_EDITOR
 
-	elif property.name == "follow_damping" and \
-	follow_mode == FollowMode.NONE:
-		property.usage = PROPERTY_USAGE_NO_EDITOR
+
+	if follow_mode == FollowMode.NONE:
+		match property.name:
+			"follow_offset", \
+			"follow_damping", \
+			"follow_damping_value":
+				property.usage = PROPERTY_USAGE_NO_EDITOR
+
+	if property.name == "follow_offset":
+		if follow_mode == FollowMode.PATH or \
+		follow_mode == FollowMode.GLUED:
+			property.usage = PROPERTY_USAGE_NO_EDITOR
 
 	if property.name == "follow_damping_value" and not follow_damping:
 		property.usage = PROPERTY_USAGE_NO_EDITOR
@@ -472,7 +477,25 @@ func _exit_tree() -> void:
 
 
 func _process(delta: float) -> void:
+	if _follow_target_physics_based: return
+	_process_logic(delta)
+
+
+func _physics_process(delta: float):
+	if not _follow_target_physics_based: return
+	_process_logic(delta)
+
+
+func _process_logic(delta: float) -> void:
 	if not _is_active:
+		_inactive_update_mode_checker()
+		return
+	_limit_checker()
+	if not _should_follow: return
+	_follow_logic(delta)
+
+
+func _inactive_update_mode_checker() -> void:
 		match inactive_update_mode:
 			InactiveUpdateMode.NEVER:
 				return
@@ -485,23 +508,27 @@ func _process(delta: float) -> void:
 #			InactiveUpdateMode.EXPONENTIALLY:
 #				TODO - Trigger positional updates less frequently as more Pcams gets added
 
+
+func _limit_checker() -> void:
 	## TODO - Needs to see if this can be triggerd only from CollisionShape2D Transform changes
 	if Engine.is_editor_hint():
 		if draw_limits:
 			update_limit_all_sides()
 
-	if not _should_follow: return
+
+func _follow_logic(delta: float) -> void:
+	var follow_position: Vector2
 
 	match follow_mode:
 		FollowMode.GLUED:
 			if follow_target:
-				_interpolate_position(follow_target.global_position)
+				follow_position = follow_target.global_position
 		FollowMode.SIMPLE:
 			if follow_target:
-				_interpolate_position(_target_position_with_offset())
+				follow_position = _target_position_with_offset()
 		FollowMode.GROUP:
 			if follow_targets.size() == 1:
-				_interpolate_position(follow_targets[0].global_position)
+				follow_position = follow_targets[0].global_position
 			elif _has_multiple_follow_targets and follow_targets.size() > 1:
 				var rect: Rect2 = Rect2(follow_targets[0].global_position, Vector2.ZERO)
 				for node in follow_targets:
@@ -520,15 +547,16 @@ func _process(delta: float) -> void:
 						zoom = clamp(screen_size.x / rect.size.x, auto_zoom_min, auto_zoom_max) * Vector2.ONE
 					else:
 						zoom = clamp(screen_size.y / rect.size.y, auto_zoom_min, auto_zoom_max) * Vector2.ONE
-				_interpolate_position(rect.get_center())
+				follow_position = rect.get_center()
 		FollowMode.PATH:
 				if follow_target and follow_path:
 					var path_position: Vector2 = follow_path.global_position
-					_interpolate_position(
+
+					follow_position = \
 						follow_path.curve.get_closest_point(
 							_target_position_with_offset() - path_position
 						) + path_position
-					)
+
 		FollowMode.FRAMED:
 			if follow_target:
 				if not Engine.is_editor_hint():
@@ -540,25 +568,28 @@ func _process(delta: float) -> void:
 
 						if dead_zone_width == 0 || dead_zone_height == 0:
 							if dead_zone_width == 0 && dead_zone_height != 0:
-								_interpolate_position(_target_position_with_offset())
+								follow_position = _target_position_with_offset()
 							elif dead_zone_width != 0 && dead_zone_height == 0:
 								glo_pos = _target_position_with_offset()
 								glo_pos.x += target_position.x - global_position.x
-								_interpolate_position(glo_pos)
+								follow_position = glo_pos
 							else:
-								_interpolate_position(_target_position_with_offset())
+								follow_position = _target_position_with_offset()
 						else:
-							_interpolate_position(target_position)
+							follow_position = target_position
 					else:
 						_follow_framed_offset = global_position - _target_position_with_offset()
 				else:
-					_interpolate_position(_target_position_with_offset())
+					follow_position = _target_position_with_offset()
+
+	_interpolate_position(follow_position, delta)
 
 
 func _set_velocity(index: int, value: float):
 	_velocity_ref[index] = value
 
-func _interpolate_position(target_position: Vector2) -> void:
+
+func _interpolate_position(target_position: Vector2, delta: float) -> void:
 	if _limit_inactive_pcam and not _has_tweened:
 		target_position = _set_limit_clamp_position(target_position)
 
@@ -571,16 +602,17 @@ func _interpolate_position(target_position: Vector2) -> void:
 					index,
 					_velocity_ref[index],
 					_set_velocity,
-					follow_damping_value[index]
+					follow_damping_value[index],
+					delta
 				)
 	else:
 		global_position = target_position
 
 
-func _smooth_damp(target_axis: float, self_axis: float, index: int, current_velocity: float, set_velocity: Callable, damping_time: float) -> float:
+func _smooth_damp(target_axis: float, self_axis: float, index: int, current_velocity: float, set_velocity: Callable, damping_time: float, delta: float) -> float:
 		damping_time = maxf(0.0001, damping_time)
 		var omega: float = 2 / damping_time
-		var x: float = omega * get_process_delta_time()
+		var x: float = omega * delta
 		var exponential: float = 1 / (1 + x + 0.48 * x * x + 0.235 * x * x * x)
 		var diff: float = self_axis - target_axis
 		var _target_axis: float = target_axis
@@ -589,14 +621,14 @@ func _smooth_damp(target_axis: float, self_axis: float, index: int, current_velo
 		diff = clampf(diff, -max_change, max_change)
 		target_axis = self_axis - diff
 
-		var temp: float = (current_velocity + omega * diff) * get_process_delta_time()
+		var temp: float = (current_velocity + omega * diff) * delta
 		set_velocity.call(index, (current_velocity - omega * temp) * exponential)
 		var output: float = target_axis + (diff + temp) * exponential
 
 		## To prevent overshooting
 		if (_target_axis - self_axis > 0.0) == (output > _target_axis):
 			output = _target_axis
-			set_velocity.call(index, (output - _target_axis) / get_process_delta_time())
+			set_velocity.call(index, (output - _target_axis) / delta)
 
 		return output
 
@@ -889,9 +921,27 @@ func set_follow_target(value: Node2D) -> void:
 	follow_target = value
 	if is_instance_valid(value):
 		_should_follow = true
+
+		## Only runs when the editor is Godot 4.3 or above
+		if follow_target is PhysicsBody2D:
+			_follow_target_physics_based = true
+			if Engine.get_version_info().major == 4 and \
+			Engine.get_version_info().minor < 3:
+				print_rich("Following a [b]PhysicsBody2D[/b] node will likely result in jitter.")
+				print_rich("Will strongly recommend upgrading to Godot 4.3 as it has built-in support for 2D Physics Interpolation.")
+				print_rich("Until then, try following the guide on the [url=_jitter_documentation]documentation site[/url] for better results.")
+			else:
+				if not ProjectSettings.get_setting("physics/common/physics_interpolation"):
+					printerr("Phantom Camera: Physics Interpolation is disabled in the Project Settings, recommend enabling it to smooth out physics movement")
+			_follow_target_physics_based = true
+
+		else:
+			_follow_target_physics_based = false
+
 	else:
 		_should_follow = false
 	follow_target_changed.emit()
+	notify_property_list_changed()
 ## Erases the current [member follow_target].
 func erase_follow_target() -> void:
 	if follow_target == null: return
@@ -1041,7 +1091,7 @@ func set_limit(side: int, value: int) -> void:
 		SIDE_RIGHT: 	limit_right = value
 		SIDE_BOTTOM: 	limit_bottom = value
 		_:				printerr("Not a valid Side.")
-## Gets the limit side 
+## Gets the limit side
 func get_limit(value: int) -> int:
 	match value:
 		SIDE_LEFT: 		return limit_left

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
@@ -1010,13 +1010,16 @@ func _check_physics_body(target: Node2D) -> void:
 		## NOTE - Feature Toggle
 		if Engine.get_version_info().major == 4 and \
 		Engine.get_version_info().minor < 3:
-			print_rich("Following a [b]PhysicsBody2D[/b] node will likely result in jitter.")
-			print_rich("Once Godot 4.3 is released, will strongly recommend upgrading to that as it has built-in support for 2D Physics Interpolation.")
-			print_rich("Until then, try following the guide on the [url=https://phantom-camera.dev/support/faq#i-m-seeing-jitter-what-can-i-do]documentation site[/url] for better results.")
+			if ProjectSettings.get_setting("phantom_camera/tips/show_jitter_tips"):
+				print_rich("Following a [b]PhysicsBody2D[/b] node will likely result in jitter.")
+				print_rich("Once Godot 4.3 is released, will strongly recommend upgrading to that as it has built-in support for 2D Physics Interpolation.")
+				print_rich("Until then, try following the guide on the [url=https://phantom-camera.dev/support/faq#i-m-seeing-jitter-what-can-i-do]documentation site[/url] for better results.")
+				print_rich("This tip can be disabled from within [code]Project Settings / Phantom Camera / Tips / Show Jitter Tips[/code]")
 			return
 		## NOTE - Only supported in Godot 4.3 or above
-		elif not ProjectSettings.get_setting("physics/common/physics_interpolation"):
+		elif not ProjectSettings.get_setting("physics/common/physics_interpolation") and ProjectSettings.get_setting("phantom_camera/tips/show_jitter_tips"):
 				printerr("Physics Interpolation is disabled in the Project Settings, recommend enabling it to smooth out physics-based camera movement")
+				print_rich("This tip can be disabled from within [code]Project Settings / Phantom Camera / Tips / Show Jitter Tips[/code]")
 		_follow_target_physics_based = true
 
 

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
@@ -489,25 +489,17 @@ func _physics_process(delta: float):
 
 func _process_logic(delta: float) -> void:
 	if not _is_active:
-		_inactive_update_mode_checker()
-		return
-	_limit_checker()
-	if not _should_follow: return
-	_follow_logic(delta)
-
-
-func _inactive_update_mode_checker() -> void:
 		match inactive_update_mode:
-			InactiveUpdateMode.NEVER:
-				return
+			InactiveUpdateMode.NEVER: return
 			InactiveUpdateMode.ALWAYS:
 				# Only triggers if limit isn't default
 				if _limit_inactive_pcam:
-					set_global_position(
-						_set_limit_clamp_position(global_position)
-					)
+					global_position = _set_limit_clamp_position(global_position)
 #			InactiveUpdateMode.EXPONENTIALLY:
 #				TODO - Trigger positional updates less frequently as more Pcams gets added
+	_limit_checker()
+	if _should_follow:
+		_follow(delta)
 
 
 func _limit_checker() -> void:
@@ -517,7 +509,7 @@ func _limit_checker() -> void:
 			update_limit_all_sides()
 
 
-func _follow_logic(delta: float) -> void:
+func _follow(delta: float) -> void:
 	var follow_position: Vector2
 
 	match follow_mode:

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
@@ -143,7 +143,7 @@ var _follow_framed_offset: Vector2 = Vector2.ZERO
 var follow_target_physics_based: bool = false:
 	set = set_follow_target_physics_based,
 	get = get_follow_target_physics_based
-var _physics_interpolation_enabled = false ## TOOD - Should be anbled once toggling physics_interpolation_mode ON, when previously OFF, works seamlessly
+var _physics_interpolation_enabled = false # NOTE - Enable for Godot 4.3 and when PhysicsInterpolationMode bug is resolved
 
 ### Defines the targets that the [param PhantomCamera2D] should be following.
 @export var follow_targets: Array[Node2D] = []:
@@ -926,25 +926,20 @@ func set_follow_target(value: Node2D) -> void:
 		_should_follow = true
 
 		if follow_target is PhysicsBody2D:
-			print_rich("Following a [b]PhysicsBody2D[/b] node will likely result in jitter.")
-			print_rich("Will have proper support once Godot support 2D Physics Interpolation.")
-			print_rich("Until then, try following the guide on the [url=https://phantom-camera.dev/support/faq#i-m-seeing-jitter-what-can-i-do]documentation site[/url] for better results.")
-
 			## NOTE - Feature Toggle
-			if _physics_interpolation_enabled:
-				follow_target_physics_based = true
-				if Engine.get_version_info().major == 4 and \
-				Engine.get_version_info().minor < 3:
-					print_rich("Following a [b]PhysicsBody2D[/b] node will likely result in jitter.")
-					print_rich("Will strongly recommend upgrading to Godot 4.3 as it has built-in support for 2D Physics Interpolation.")
-					print_rich("Until then, try following the guide on the [url=https://phantom-camera.dev/support/faq#i-m-seeing-jitter-what-can-i-do]documentation site[/url] for better results.")
-				else:
-					## NOTE - Only supported in Godot 4.3 or above
-					if not ProjectSettings.get_setting("physics/common/physics_interpolation"):
-						printerr("Phantom Camera: Physics Interpolation is disabled in the Project Settings, recommend enabling it to smooth out physics movement")
-				follow_target_physics_based = true
+			follow_target_physics_based = true
+			if Engine.get_version_info().major == 4 and \
+			Engine.get_version_info().minor < 3:
+				print_rich("Following a [b]PhysicsBody2D[/b] node will likely result in jitter.")
+				print_rich("Will strongly recommend upgrading to Godot 4.3 as it has built-in support for 2D Physics Interpolation.")
+				print_rich("Until then, try following the guide on the [url=https://phantom-camera.dev/support/faq#i-m-seeing-jitter-what-can-i-do]documentation site[/url] for better results.")
 			else:
-				follow_target_physics_based = false
+				## NOTE - Only supported in Godot 4.3 or above
+				if not ProjectSettings.get_setting("physics/common/physics_interpolation"):
+					printerr("Phantom Camera: Physics Interpolation is disabled in the Project Settings, recommend enabling it to smooth out physics movement")
+			follow_target_physics_based = true
+		else:
+			follow_target_physics_based = false
 	else:
 		_should_follow = false
 	follow_target_changed.emit()

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
@@ -933,13 +933,13 @@ func set_follow_target(value: Node2D) -> void:
 			## NOTE - Feature Toggle
 			if _physics_interpolation_enabled:
 				follow_target_physics_based = true
-				## NOTE - Only supported in Godot 4.3 or above
 				if Engine.get_version_info().major == 4 and \
 				Engine.get_version_info().minor < 3:
 					print_rich("Following a [b]PhysicsBody2D[/b] node will likely result in jitter.")
 					print_rich("Will strongly recommend upgrading to Godot 4.3 as it has built-in support for 2D Physics Interpolation.")
 					print_rich("Until then, try following the guide on the [url=https://phantom-camera.dev/support/faq#i-m-seeing-jitter-what-can-i-do]documentation site[/url] for better results.")
 				else:
+					## NOTE - Only supported in Godot 4.3 or above
 					if not ProjectSettings.get_setting("physics/common/physics_interpolation"):
 						printerr("Phantom Camera: Physics Interpolation is disabled in the Project Settings, recommend enabling it to smooth out physics movement")
 				follow_target_physics_based = true

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
@@ -140,7 +140,10 @@ var pcam_host_owner: PhantomCameraHost = null:
 	get = get_follow_target
 var _should_follow: bool = false
 var _follow_framed_offset: Vector2 = Vector2.ZERO
-var _follow_target_physics_based: bool = false
+var follow_target_physics_based: bool = false:
+	set = set_follow_target_physics_based,
+	get = get_follow_target_physics_based
+var _physics_interpolation_enabled = false ## TOOD - Should be anbled once toggling physics_interpolation_mode ON, when previously OFF, works seamlessly
 
 ### Defines the targets that the [param PhantomCamera2D] should be following.
 @export var follow_targets: Array[Node2D] = []:
@@ -477,12 +480,12 @@ func _exit_tree() -> void:
 
 
 func _process(delta: float) -> void:
-	if _follow_target_physics_based: return
+	if follow_target_physics_based: return
 	_process_logic(delta)
 
 
 func _physics_process(delta: float):
-	if not _follow_target_physics_based: return
+	if not follow_target_physics_based: return
 	_process_logic(delta)
 
 
@@ -922,22 +925,26 @@ func set_follow_target(value: Node2D) -> void:
 	if is_instance_valid(value):
 		_should_follow = true
 
-		## Only runs when the editor is Godot 4.3 or above
 		if follow_target is PhysicsBody2D:
-			_follow_target_physics_based = true
-			if Engine.get_version_info().major == 4 and \
-			Engine.get_version_info().minor < 3:
-				print_rich("Following a [b]PhysicsBody2D[/b] node will likely result in jitter.")
-				print_rich("Will strongly recommend upgrading to Godot 4.3 as it has built-in support for 2D Physics Interpolation.")
-				print_rich("Until then, try following the guide on the [url=_jitter_documentation]documentation site[/url] for better results.")
+			print_rich("Following a [b]PhysicsBody2D[/b] node will likely result in jitter.")
+			print_rich("Will have proper support once Godot support 2D Physics Interpolation.")
+			print_rich("Until then, try following the guide on the [url=https://phantom-camera.dev/support/faq#i-m-seeing-jitter-what-can-i-do]documentation site[/url] for better results.")
+
+			## NOTE - Feature Toggle
+			if _physics_interpolation_enabled:
+				follow_target_physics_based = true
+				## NOTE - Only supported in Godot 4.3 or above
+				if Engine.get_version_info().major == 4 and \
+				Engine.get_version_info().minor < 3:
+					print_rich("Following a [b]PhysicsBody2D[/b] node will likely result in jitter.")
+					print_rich("Will strongly recommend upgrading to Godot 4.3 as it has built-in support for 2D Physics Interpolation.")
+					print_rich("Until then, try following the guide on the [url=https://phantom-camera.dev/support/faq#i-m-seeing-jitter-what-can-i-do]documentation site[/url] for better results.")
+				else:
+					if not ProjectSettings.get_setting("physics/common/physics_interpolation"):
+						printerr("Phantom Camera: Physics Interpolation is disabled in the Project Settings, recommend enabling it to smooth out physics movement")
+				follow_target_physics_based = true
 			else:
-				if not ProjectSettings.get_setting("physics/common/physics_interpolation"):
-					printerr("Phantom Camera: Physics Interpolation is disabled in the Project Settings, recommend enabling it to smooth out physics movement")
-			_follow_target_physics_based = true
-
-		else:
-			_follow_target_physics_based = false
-
+				follow_target_physics_based = false
 	else:
 		_should_follow = false
 	follow_target_changed.emit()
@@ -1207,5 +1214,10 @@ func set_inactive_update_mode(value: int) -> void:
 ## Gets [enum InactiveUpdateMode] value.
 func get_inactive_update_mode() -> int:
 	return inactive_update_mode
+
+func set_follow_target_physics_based(value: bool) -> void:
+	follow_target_physics_based = value
+func get_follow_target_physics_based() -> bool:
+	return follow_target_physics_based
 
 #endregion

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -1305,7 +1305,9 @@ func append_look_at_target(value: Node3D) -> void:
 	if not look_at_targets.has(value):
 		look_at_targets.append(value)
 		_valid_look_at_targets.append(value)
-		_multiple_look_at_targets = true
+		_check_physics_body(value)
+		if look_at_targets.size() > 1:
+			_multiple_look_at_targets = true
 	else:
 		printerr(value, " is already part of Look At Group")
 ## Appends an array of type [Node3D] to [member look_at_targets] array.
@@ -1321,6 +1323,7 @@ func append_look_at_targets_array(value: Array[NodePath]) -> void:
 func erase_look_at_targets_member(value: Node3D) -> void:
 	look_at_targets.erase(value)
 	_valid_look_at_targets.erase(value)
+	_check_physics_body(value)
 	if look_at_targets.size() < 1:
 		_multiple_look_at_targets = false
 ## Gets all the [Node3D] instances in [member look_at_targets].

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -160,6 +160,7 @@ var _is_active: bool = false
 	get = get_follow_target
 var _should_follow: bool = false
 var _follow_target_physics_based: bool = false
+var _physics_interpolation_enabled = false ## TOOD - Should be anbled once toggling physics_interpolation_mode ON, when previously OFF, works in 3D
 
 ## Defines the targets that the [param PhantomCamera3D] should be following.
 @export var follow_targets: Array[Node3D] = []:
@@ -998,7 +999,6 @@ func set_follow_target(value: Node3D) -> void:
 	if follow_target == value: return
 	follow_target = value
 
-
 	if is_instance_valid(value):
 		_should_follow = true
 
@@ -1006,8 +1006,8 @@ func set_follow_target(value: Node3D) -> void:
 			#_follow_target_physics_based = true
 			print_rich("Following a [b]PhysicsBody3D[/b] node will likely result in jitter.")
 			print_rich("Will have proper support once Godot support 3D Physics Interpolation.")
-			print_rich("Until then, try following the guide on the [url=_jitter_documentation]documentation site[/url] for better results.")
-			_follow_target_physics_based = false
+			print_rich("Until then, try following the guide on the [url=https://phantom-camera.dev/support/faq#i-m-seeing-jitter-what-can-i-do]documentation site[/url] for better results.")
+			_follow_target_physics_based = true
 		else:
 			_follow_target_physics_based = false
 	else:

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -1311,12 +1311,14 @@ func append_look_at_target(value: Node3D) -> void:
 	else:
 		printerr(value, " is already part of Look At Group")
 ## Appends an array of type [Node3D] to [member look_at_targets] array.
-func append_look_at_targets_array(value: Array[NodePath]) -> void:
+func append_look_at_targets_array(value: Array[Node3D]) -> void:
 	for val in value:
 		if not look_at_targets.has(val):
 			look_at_targets.append(val)
 			_valid_look_at_targets.append(val)
-			_multiple_look_at_targets = true
+			_check_physics_body(val)
+			if look_at_targets.size() > 1:
+				_multiple_look_at_targets = true
 		else:
 			printerr(val, " is already part of Look At Group")
 ## Removes [Node3D] from [member look_at_targets] array.

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -673,6 +673,7 @@ func _follow_logic(delta: float) -> void:
 					else:
 						_follow_framed_offset = global_position - _get_target_position_offset()
 						_current_rotation = global_rotation
+						return
 				else:
 					follow_position = _get_position_offset_distance()
 					var unprojected_position: Vector2 = _get_raw_unprojected_position()

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -1097,10 +1097,12 @@ func _check_physics_body(target: Node3D) -> void:
 		## NOTE - Feature Toggle
 		#if Engine.get_version_info().major == 4 and \
 		#Engine.get_version_info().minor < XX:
-			print_rich("Following a [b]PhysicsBody3D[/b] node will likely result in jitter.")
+		if ProjectSettings.get_setting("phantom_camera/tips/show_jitter_tips"):
+			print_rich("Following or Looking at a [b]PhysicsBody3D[/b] node will likely result in jitter.")
 			print_rich("Will have proper support once 3D Physics Interpolation becomes part of the core Godot engine.")
 			print_rich("Until then, try following the guide on the [url=https://phantom-camera.dev/support/faq#i-m-seeing-jitter-what-can-i-do]documentation site[/url] for better results.")
-			return
+			print_rich("This tip can be disabled from within [code]Project Settings / Phantom Camera / Tips / Show Jitter Tips[/code]")
+		return
 		## TODO - Enable once Godot supports 3D Physics Interpolation
 		#elif not ProjectSettings.get_setting("physics/common/physics_interpolation"):
 				#printerr("Physics Interpolation is disabled in the Project Settings, recommend enabling it to smooth out physics-based camera movement")
@@ -1126,7 +1128,6 @@ func get_follow_damping() -> bool:
 
 ## Assigns new [member follow_damping_value] value.
 func set_follow_damping_value(value: Vector3) -> void:
-
 	## TODO - Should be using @export_range once minimum version support is Godot 4.3
 	if value.x < 0: value.x = 0
 	elif value.y < 0: value.y = 0
@@ -1259,6 +1260,7 @@ func get_look_at_mode() -> int:
 ## Assigns new [Node3D] as [member look_at_target].
 func set_look_at_target(value: Node3D) -> void:
 	look_at_target = value
+	_check_physics_body(value)
 	#_look_at_target_node = get_node_or_null(value)
 	look_at_target_changed
 	if is_instance_valid(look_at_target):
@@ -1289,6 +1291,7 @@ func set_look_at_targets(value: Array[Node3D]) -> void:
 				valid_instances += 1
 				_should_look_at = true
 				_valid_look_at_targets.append(target)
+				_check_physics_body(target)
 
 			if valid_instances > 1:
 				_multiple_look_at_targets = true

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -566,24 +566,17 @@ func _physics_process(delta: float):
 
 func _process_logic(delta: float) -> void:
 	if not _is_active:
-		_inactive_update_mode_checker()
-
-	if _should_follow:
-		_follow_logic(delta)
-
-	if _should_look_at:
-		_look_at_logic()
-
-func _inactive_update_mode_checker() -> void:
-	if not _is_active:
 		match inactive_update_mode:
-			InactiveUpdateMode.NEVER:
-				return
-#			InactiveUpdateMode.EXPONENTIALLY:
-#				TODO - Trigger positional updates less frequently as more Pcams gets added
+			InactiveUpdateMode.NEVER:	return
+			# InactiveUpdateMode.EXPONENTIALLY:
+			# TODO - Trigger positional updates less frequently as more Pcams gets added
+	if _should_follow:
+		_follow(delta)
+	if _should_look_at:
+		_look_at() # TODO - Delta needs to be applied, pending Godot's 3D Physics Interpolation to be implemented
 
 
-func _follow_logic(delta: float) -> void:
+func _follow(delta: float) -> void:
 	var follow_position: Vector3
 	var follow_target_node: Node3D = self
 
@@ -707,7 +700,7 @@ func _follow_logic(delta: float) -> void:
 
 	_interpolate_position(follow_position, delta, follow_target_node)
 
-func _look_at_logic() -> void:
+func _look_at() -> void:
 	match look_at_mode:
 		LookAtMode.MIMIC:
 			global_rotation = look_at_target.global_rotation

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -674,7 +674,7 @@ func _follow_logic(delta: float) -> void:
 						_follow_framed_offset = global_position - _get_target_position_offset()
 						_current_rotation = global_rotation
 				else:
-					global_position = _get_position_offset_distance()
+					follow_position = _get_position_offset_distance()
 					var unprojected_position: Vector2 = _get_raw_unprojected_position()
 					var viewport_width: float = get_viewport().size.x
 					var viewport_height: float = get_viewport().size.y

--- a/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
+++ b/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
@@ -191,18 +191,23 @@ func _assign_new_active_pcam(pcam: Node) -> void:
 			#else:
 				#_physics_based = _active_pcam.follow_target_physics_based
 
-			# TBD - REMOVE once Godot 4.3 becomes the minimum version
-			_physics_based = _active_pcam.follow_target_physics_based
+			# TBD - REMOVE this line once Godot 4.3 becomes the minimum version
+			_physics_based = _active_pcam.get_follow_target_physics_based()
 
 			if _physics_based:
 				_follow_target_physics_based = true
-				_active_pcam.follow_target_physics_based = true
-				## INFO - Enable for Godot 4.3
+				_active_pcam.set_follow_target_physics_based(true, self)
+				## TODO - Temporary solution to support Godot 4.2
+				## Remove string-based caller and setter below and uncomment the following once Godot 4.3 is min verison.
+				camera_2d.call("reset_physics_interpolation")
+				camera_2d.set("physics_interpolation_mode", 1)
 				#camera_2d.physics_interpolation_mode = Node.PHYSICS_INTERPOLATION_MODE_ON
 			else:
 				_follow_target_physics_based = false
-				_active_pcam.follow_target_physics_based = false
-				## INFO - Enable for Godot 4.3
+				_active_pcam.set_follow_target_physics_based(false, self)
+				## TODO - Temporary solution to support Godot 4.2
+				## Remove line below and uncomment the following once Godot 4.3 is min verison.
+				camera_2d.set("physics_interpolation_mode", 2)
 				#camera_2d.physics_interpolation_mode = Node.PHYSICS_INTERPOLATION_MODE_OFF
 	else:
 		if _active_pcam.get_camera_3d_resource():

--- a/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
+++ b/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
@@ -51,7 +51,6 @@ var _active_pcam_priority: int = -1
 var _active_pcam_missing: bool = true
 var _active_pcam_has_damping: bool = false
 var _follow_target_physics_based: bool = false
-var _physics_interpolation_enabled = true ## TOOD - Should be anbled once toggling physics_interpolation_mode ON, when previously OFF, works seamlessly
 
 var _prev_active_pcam_2d_transform: Transform2D = Transform2D()
 var _prev_active_pcam_3d_transform: Transform3D = Transform3D()
@@ -198,9 +197,10 @@ func _assign_new_active_pcam(pcam: Node) -> void:
 				_follow_target_physics_based = true
 				_active_pcam.set_follow_target_physics_based(true, self)
 				## TODO - Temporary solution to support Godot 4.2
-				## Remove string-based caller and setter below and uncomment the following once Godot 4.3 is min verison.
+				## Remove line below and uncomment the following once Godot 4.3 is min verison.
 				camera_2d.call("reset_physics_interpolation")
 				camera_2d.set("physics_interpolation_mode", 1)
+				#camera_2d.reset_physics_interpolation()
 				#camera_2d.physics_interpolation_mode = Node.PHYSICS_INTERPOLATION_MODE_ON
 			else:
 				_follow_target_physics_based = false

--- a/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
+++ b/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
@@ -33,9 +33,10 @@ enum InterpolationMode {
 	PHYSICS = 2,
 }
 
-@export var interpolation_mode: InterpolationMode = InterpolationMode.AUTO:
-	set = set_interpolation_mode,
-	get = get_interpolation_mode
+## TODO - For when Godot 4.3 becomes a minimum version
+#@export var interpolation_mode: InterpolationMode = InterpolationMode.AUTO:
+	#set = set_interpolation_mode,
+	#get = get_interpolation_mode
 
 
 ## For 2D scenes, is the [Camera2D] instance the [param PhantomCameraHost] controls.
@@ -81,11 +82,11 @@ var _active_pcam_3d_glob_transform: Transform3D = Transform3D()
 
 #region Private Functions
 
-
-func _validate_property(property: Dictionary) -> void:
-	if property.name == "interpolation_mode" and get_parent() is Node3D or \
-	not _physics_interpolation_enabled:
-		property.usage = PROPERTY_USAGE_NO_EDITOR
+## TODO - For when Godot 4.3 becomes a minimum version
+#func _validate_property(property: Dictionary) -> void:
+	#if property.name == "interpolation_mode" and get_parent() is Node3D or \
+	#not _physics_interpolation_enabled:
+		#property.usage = PROPERTY_USAGE_NO_EDITOR
 
 
 func _enter_tree() -> void:
@@ -185,21 +186,24 @@ func _assign_new_active_pcam(pcam: Node) -> void:
 			## NOTE - Only supported in Godot 4.3 or above
 			if Engine.get_version_info().major == 4 and \
 			Engine.get_version_info().minor >= 3:
-				if interpolation_mode == InterpolationMode.IDLE:
-					_physics_based = false
-				elif interpolation_mode == InterpolationMode.PHYSICS:
-					_physics_based = true
-				else:
-					_physics_based = _active_pcam.follow_target_physics_based
+				## TODO - For when Godot 4.3 becomes a minimum version
+				#if interpolation_mode == InterpolationMode.IDLE:
+					#_physics_based = false
+				#elif interpolation_mode == InterpolationMode.PHYSICS:
+					#_physics_based = true
+				#else:
+					#_physics_based = _active_pcam.follow_target_physics_based
 
 				if _physics_based:
 					_follow_target_physics_based = true
 					_active_pcam.follow_target_physics_based = true
-					camera_2d.physics_interpolation_mode = 1 # TODO - Replace with Node.PHYSICS_INTERPOLATION_MODE_ON once minimum version is 4.3+
+					## TODO - For when Godot 4.3 becomes a minimum version
+					#camera_2d.physics_interpolation_mode = Node.PHYSICS_INTERPOLATION_MODE_OFF ## TODO - For when Godot 4.3 becomes a minimum version
 				else:
 					_follow_target_physics_based = false
 					_active_pcam.follow_target_physics_based = false
-					camera_2d.physics_interpolation_mode = 2 # TODO - Replace with Node.PHYSICS_INTERPOLATION_MODE_OFF once minimum version is 4.3+
+					## TODO - For when Godot 4.3 becomes a minimum version
+					#camera_2d.physics_interpolation_mode = Node.PHYSICS_INTERPOLATION_MODE_OFF ## TODO - For when Godot 4.3 becomes a minimum version
 	else:
 		if _active_pcam.get_camera_3d_resource():
 			camera_3d.cull_mask = _active_pcam.get_cull_mask()
@@ -477,9 +481,9 @@ func get_active_pcam() -> Node:
 func get_trigger_pcam_tween() -> bool:
 	return _trigger_pcam_tween
 
-func set_interpolation_mode(value: int) -> void:
-	interpolation_mode = value
-func get_interpolation_mode() -> int:
-	return interpolation_mode
+#func set_interpolation_mode(value: int) -> void:
+	#interpolation_mode = value
+#func get_interpolation_mode() -> int:
+	#return interpolation_mode
 
 #endregion

--- a/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
+++ b/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
@@ -198,12 +198,12 @@ func _assign_new_active_pcam(pcam: Node) -> void:
 					_follow_target_physics_based = true
 					_active_pcam.follow_target_physics_based = true
 					## TODO - For when Godot 4.3 becomes a minimum version
-					#camera_2d.physics_interpolation_mode = Node.PHYSICS_INTERPOLATION_MODE_OFF ## TODO - For when Godot 4.3 becomes a minimum version
+					#camera_2d.physics_interpolation_mode = Node.PHYSICS_INTERPOLATION_MODE_OFF
 				else:
 					_follow_target_physics_based = false
 					_active_pcam.follow_target_physics_based = false
 					## TODO - For when Godot 4.3 becomes a minimum version
-					#camera_2d.physics_interpolation_mode = Node.PHYSICS_INTERPOLATION_MODE_OFF ## TODO - For when Godot 4.3 becomes a minimum version
+					#camera_2d.physics_interpolation_mode = Node.PHYSICS_INTERPOLATION_MODE_OFF
 	else:
 		if _active_pcam.get_camera_3d_resource():
 			camera_3d.cull_mask = _active_pcam.get_cull_mask()

--- a/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
+++ b/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
@@ -33,7 +33,7 @@ enum InterpolationMode {
 	PHYSICS = 2,
 }
 
-## TODO - For when Godot 4.3 becomes a minimum version
+## TBD - For when Godot 4.3 becomes the minimum version
 #@export var interpolation_mode: InterpolationMode = InterpolationMode.AUTO:
 	#set = set_interpolation_mode,
 	#get = get_interpolation_mode
@@ -51,7 +51,7 @@ var _active_pcam_priority: int = -1
 var _active_pcam_missing: bool = true
 var _active_pcam_has_damping: bool = false
 var _follow_target_physics_based: bool = false
-var _physics_interpolation_enabled = false ## TOOD - Should be anbled once toggling physics_interpolation_mode ON, when previously OFF, works seamlessly
+var _physics_interpolation_enabled = true ## TOOD - Should be anbled once toggling physics_interpolation_mode ON, when previously OFF, works seamlessly
 
 var _prev_active_pcam_2d_transform: Transform2D = Transform2D()
 var _prev_active_pcam_3d_transform: Transform3D = Transform3D()
@@ -82,10 +82,9 @@ var _active_pcam_3d_glob_transform: Transform3D = Transform3D()
 
 #region Private Functions
 
-## TODO - For when Godot 4.3 becomes a minimum version
+## TBD - For when Godot 4.3 becomes a minimum version
 #func _validate_property(property: Dictionary) -> void:
-	#if property.name == "interpolation_mode" and get_parent() is Node3D or \
-	#not _physics_interpolation_enabled:
+	#if property.name == "interpolation_mode" and get_parent() is Node3D:
 		#property.usage = PROPERTY_USAGE_NO_EDITOR
 
 
@@ -181,29 +180,30 @@ func _assign_new_active_pcam(pcam: Node) -> void:
 		## TODO - Needs 3D variant once Godot supports physics_interpolation for 3D scenes.
 		var _physics_based: bool
 
-		## NOTE - Feature Toggle
-		if _physics_interpolation_enabled:
-			## NOTE - Only supported in Godot 4.3 or above
-			if Engine.get_version_info().major == 4 and \
-			Engine.get_version_info().minor >= 3:
-				## TODO - For when Godot 4.3 becomes a minimum version
-				#if interpolation_mode == InterpolationMode.IDLE:
-					#_physics_based = false
-				#elif interpolation_mode == InterpolationMode.PHYSICS:
-					#_physics_based = true
-				#else:
-					#_physics_based = _active_pcam.follow_target_physics_based
+		## NOTE - Only supported in Godot 4.3 or above
+		if Engine.get_version_info().major == 4 and \
+		Engine.get_version_info().minor >= 3:
+			## TBD - For when Godot 4.3 becomes the minimum version
+			#if interpolation_mode == InterpolationMode.IDLE:
+				#_physics_based = false
+			#elif interpolation_mode == InterpolationMode.PHYSICS:
+				#_physics_based = true
+			#else:
+				#_physics_based = _active_pcam.follow_target_physics_based
 
-				if _physics_based:
-					_follow_target_physics_based = true
-					_active_pcam.follow_target_physics_based = true
-					## TODO - For when Godot 4.3 becomes a minimum version
-					#camera_2d.physics_interpolation_mode = Node.PHYSICS_INTERPOLATION_MODE_OFF
-				else:
-					_follow_target_physics_based = false
-					_active_pcam.follow_target_physics_based = false
-					## TODO - For when Godot 4.3 becomes a minimum version
-					#camera_2d.physics_interpolation_mode = Node.PHYSICS_INTERPOLATION_MODE_OFF
+			# TBD - REMOVE once Godot 4.3 becomes the minimum version
+			_physics_based = _active_pcam.follow_target_physics_based
+
+			if _physics_based:
+				_follow_target_physics_based = true
+				_active_pcam.follow_target_physics_based = true
+				## INFO - Enable for Godot 4.3
+				#camera_2d.physics_interpolation_mode = Node.PHYSICS_INTERPOLATION_MODE_ON
+			else:
+				_follow_target_physics_based = false
+				_active_pcam.follow_target_physics_based = false
+				## INFO - Enable for Godot 4.3
+				#camera_2d.physics_interpolation_mode = Node.PHYSICS_INTERPOLATION_MODE_OFF
 	else:
 		if _active_pcam.get_camera_3d_resource():
 			camera_3d.cull_mask = _active_pcam.get_cull_mask()


### PR DESCRIPTION
> [!IMPORTANT]
> Both Godot 4.2 and 4.3 are supported, however the enhancements here will only work for Godot 4.3 dev6 or later.

> [!IMPORTANT]
> The changes only affect 2D scenes.
> 3D phyics interpolation are **not** yet supported in Godot and will be added in a future release.

# What is this?
This change applies the newly added physics interpolation that was included in [Godot 4.3 dev 6](https://godotengine.org/article/dev-snapshot-godot-4-3-dev-6/) release.
The changes in this PR allows a `PCam2D` to support having a `follow target` of either a `PhysicsBody2D`-based or a non-`PhysicsBody2D`-based node, where the `Camera2D` will then automatically adjust its interpolation mode to match. Resulting in a jitter-free movement.

Before this, the user had to make use of either the smoothing-addon or implement their own solution to interpolate visuals as mentioned in [the documentation](https://phantom-camera.dev/support/faq#i-m-seeing-jitter-what-can-i-do).

## For Godot 4.2
This release will still be compatible with Godot 4.2. It does a few checks to confirm the version and disables the added functionality while retaining existing behaviour. So nothing should be worse or better from this change.

> [!NOTE]
> It will encourage to upgrade to Godot 4.3 if one attempts to select a `PhysicsBody2D` as a `follow target` or `follow targets` (Group Follow).

## For Godot 4.3
### Project Settings
- Enable the `Physics Interpolation`, inside `physics/common/physics_interpolation`
  - `Advanced Settings` will likely need to be enabled to see it.

<details>

### PhantomCameraHost
~~To enable the newly added physics interpolation, uncomment the following two lines inside `PhantomCameraHost.gd` on line `201` and `206`.~~

```gdscript
camera_2d.physics_interpolation_mode = Node.PHYSICS_INTERPOLATION_MODE_ON
```

```gdscript
camera_2d.physics_interpolation_mode = Node.PHYSICS_INTERPOLATION_MODE_OFF
```

Do no uncomment those lines in Godot 4.2 as that will likely crash the editor.

</details>

# Known Issues
> [!NOTE]
> All known issues have now been addressed.

~~Switching to a `PCam2D` that has a `PhysicsBody2D` `follow target` from another `PCam2D` that either has no `follow target` or a non-`PhysicsBody2D` `follow target` will cause a sudden camera flickering on the first few frames. The tween still triggers, but the effect is very noticeable and not good enough for release.~~

~~This appears to be due to setting the `Camera2D`'s `physics_interpolation_mode` to `Node.PHYSICS_INTERPOLATION_MODE_ON` from having previously being `Node.PHYSICS_INTERPOLATION_MODE_OFF`.~~

## Notes
- ~~This issue is only appearing when enabling it after it has been disabled, and not the other way around.~~
- ~~This appears to occur independently of the addon and occurs in simple projects too~~