### PR TITLE
Only show viewfinder if the active PCam's mode is framed

### DIFF
--- a/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
+++ b/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
@@ -324,21 +324,21 @@ func _process(delta):
 #region Public Functions
 
 func _show_viewfinder_in_play() -> void:
+	# Don't show the viewfinder in the actual editor or project builds
+	if Engine.is_editor_hint() or !OS.has_feature("editor"):
+		return
+
 	# We default the viewfinder node to hidden
 	if is_instance_valid(_viewfinder_node):
 		_viewfinder_node.visible = false
+
+	if !_active_pcam.show_viewfinder_in_play:
+		return
 
 	var _typed_active_pcam = (_active_pcam as PhantomCamera2D) if _is_2D else (_active_pcam as PhantomCamera3D)
 	assert(_typed_active_pcam != null, "The current active PCam couldn't be properly type-cast")
 
 	if _typed_active_pcam.follow_mode != _typed_active_pcam.FollowMode.FRAMED:
-		return
-
-	if !_active_pcam.show_viewfinder_in_play:
-		return
-
-	# Don't show the viewfinder in the actual editor or project builds
-	if Engine.is_editor_hint() or !OS.has_feature("editor"):
 		return
 
 	var canvas_layer: CanvasLayer = CanvasLayer.new()

--- a/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
+++ b/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
@@ -335,10 +335,7 @@ func _show_viewfinder_in_play() -> void:
 	if !_active_pcam.show_viewfinder_in_play:
 		return
 
-	var _typed_active_pcam = (_active_pcam as PhantomCamera2D) if _is_2D else (_active_pcam as PhantomCamera3D)
-	assert(_typed_active_pcam != null, "The current active PCam couldn't be properly type-cast")
-
-	if _typed_active_pcam.follow_mode != _typed_active_pcam.FollowMode.FRAMED:
+	if _active_pcam.follow_mode != _active_pcam.FollowMode.FRAMED:
 		return
 
 	var canvas_layer: CanvasLayer = CanvasLayer.new()

--- a/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
+++ b/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
@@ -324,7 +324,7 @@ func _process(delta):
 #region Public Functions
 
 func _show_viewfinder_in_play() -> void:
-	# We hide the viewfinder scene, and only show it if we pass early returns
+	# We default the viewfinder node to hidden
 	if is_instance_valid(_viewfinder_node):
 		_viewfinder_node.visible = false
 
@@ -337,6 +337,7 @@ func _show_viewfinder_in_play() -> void:
 	if !_active_pcam.show_viewfinder_in_play:
 		return
 
+	# Don't show the viewfinder in the actual editor or project builds
 	if Engine.is_editor_hint() or !OS.has_feature("editor"):
 		return
 


### PR DESCRIPTION
Currently, if you check a `PCam`'s `show_viewfinder_in_play` checkbox, switch its `follow_mode` to one that isn't `FollowMode.FRAMED`, and then run the scene from the editor, the camera's viewfinder still gets shown.

This PR adds a check for the current `_active_pcam`'s follow mode (by casting it to either `PhantomCamera2D` or `PhantomCamera3D`) and refactors the `_show_viewfinder_in_play()` function to reduce nesting, improving readability.