### PR TITLE
Update viewfinder.gd

### DIFF
--- a/addons/phantom_camera/scripts/panel/viewfinder/viewfinder.gd
+++ b/addons/phantom_camera/scripts/panel/viewfinder/viewfinder.gd
@@ -215,12 +215,26 @@ func visibility_check() -> void:
 
 
 func _get_camera_2d() -> Camera2D:
-	var camerasGroupName = "__cameras_%d" % EditorInterface.get_edited_scene_root().get_viewport().get_viewport_rid().get_id()
+	var edited_scene_root = EditorInterface.get_edited_scene_root()
+	
+	if edited_scene_root == null:
+		return null
+	
+	var viewport = edited_scene_root.get_viewport()
+	if viewport == null:
+		return null
+	
+	var viewport_rid = viewport.get_viewport_rid()
+	if viewport_rid == null:
+		return null
+	
+	var camerasGroupName = "__cameras_%d" % viewport_rid.get_id()
 	var cameras = get_tree().get_nodes_in_group(camerasGroupName)
 
 	for camera in cameras:
 		if camera is Camera2D and camera.is_current:
 			return camera
+	
 	return null
 
 


### PR DESCRIPTION
fix the following error:
res://addons/phantom_camera/scripts/panel/viewfinder/viewfinder.gd:218 - Cannot call method 'get_viewport_rid' on a null value error

how to reproduce error:
when the addon is enabled and a root node of a scene is changed from any node that inherits from Node3D/Node2D to any other scene that does not inherit Node3D/Node2D the addon tries to calculate new previews for the phantom camera tab which results in throwing an error.

https://github.com/user-attachments/assets/8751313e-894b-482c-ade7-564544d1131b

this update fixes the function as to not throw errors