### PR TITLE
PCam2d: Stop errors on null in follow_targets.

### DIFF
--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
@@ -553,6 +553,7 @@ func _follow(delta: float) -> void:
 			elif _has_multiple_follow_targets and follow_targets.size() > 1:
 				var rect: Rect2 = Rect2(follow_targets[0].global_position, Vector2.ZERO)
 				for node in follow_targets:
+					if not node: continue
 					rect = rect.expand(node.global_position)
 					if auto_zoom:
 						rect = rect.grow_individual(


### PR DESCRIPTION
Because the phantom camera updates its position in the editor, if you are in FollowMode.GROUP and you go to add a node to follow_targets, upon clicking "+ Add Element" the camera will try and get the global position of the new null element (as you have not had time to set it yet) causing errors to be output every frame. Now null elements will simply be skipped.