### PR TITLE
Add link hint on zoom property

### DIFF
--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
@@ -166,7 +166,7 @@ var _has_follow_path: bool = false
 
 ## Applies a zoom level to the [param PhantomCamera2D], which effectively
 ## overrides the [param zoom] property of the [param Camera2D] node.
-@export var zoom: Vector2 = Vector2.ONE:
+@export_custom(PROPERTY_HINT_LINK, "") var zoom: Vector2 = Vector2.ONE:
 	set = set_zoom,
 	get = get_zoom
 


### PR DESCRIPTION
Adds link button, like in scale property, which keeps aspect of zoom.

![CleanShot 2024-10-14 at 21 05 43@2x](https://github.com/user-attachments/assets/42d11182-87d9-458e-b179-498208364d95)
