### PR TITLE
Add checks to prevent a crash when closing the editor

### DIFF
--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
@@ -580,7 +580,8 @@ func _enter_tree() -> void:
 
 
 func _exit_tree() -> void:
-	_phantom_camera_manager.pcam_removed(self)
+	if is_instance_valid(_phantom_camera_manager):
+		_phantom_camera_manager.pcam_removed(self)
 
 	if _has_valid_pcam_owner():
 		get_pcam_host_owner().pcam_removed_from_scene(self)

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -701,7 +701,8 @@ func _enter_tree() -> void:
 
 
 func _exit_tree() -> void:
-	_phantom_camera_manager.pcam_removed(self)
+	if is_instance_valid(_phantom_camera_manager):
+		_phantom_camera_manager.pcam_removed(self)
 
 	if _has_valid_pcam_owner():
 		get_pcam_host_owner().pcam_removed_from_scene(self)

--- a/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
+++ b/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
@@ -255,8 +255,9 @@ func _enter_tree() -> void:
 
 
 func _exit_tree() -> void:
-	_phantom_camera_manager.pcam_host_removed(self)
-	_check_camera_host_amount()
+	if is_instance_valid(_phantom_camera_manager):
+		_phantom_camera_manager.pcam_host_removed(self)
+		_check_camera_host_amount()
 
 
 func _ready() -> void:


### PR DESCRIPTION
Upon quitting the Godot editor, it seems the manager singleton gets invalidated before the scene is removed, leading to a segfault when phantom cameras and host try to unregister themselves.

Only happens when quitting the editor, not when quitting a game.

Fixes #389