### PR TITLE
Avoid error accessing get_tree()

### DIFF
--- a/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
+++ b/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
@@ -637,8 +637,7 @@ func _check_pcam_physics() -> void:
 		## NOTE - Only supported in Godot 4.4 or later
 		if Engine.get_version_info().major == 4 and \
 		Engine.get_version_info().minor >= 4:
-			if get_tree().physics_interpolation or _active_pcam_3d.get_follow_target_physics_based():
-				#if get_tree().physics_interpolation or _active_pcam_3d.get_follow_target_physics_based():
+			if is_inside_tree() and get_tree().physics_interpolation or _active_pcam_3d.get_follow_target_physics_based():
 				_follow_target_physics_based = true
 				## TODO - Temporary solution to support Godot 4.2
 				## Remove line below and uncomment the following once Godot 4.3 is min verison.


### PR DESCRIPTION
I'm using Godot 4.4 and I get this error when closing the game:

```
E 0:00:21:144   phantom_camera_host.gd:557 @ _check_pcam_physics(): Parameter "data.tree" is null.
  <C++ Source>  scene/main/node.h:485 @ get_tree()
  <Stack Trace> phantom_camera_host.gd:557 @ _check_pcam_physics()
                phantom_camera_3d.gd:1236 @ _check_physics_body()
                phantom_camera_3d.gd:1197 @ _look_at_targets_size_check()
                phantom_camera_3d.gd:1727 @ erase_look_at_targets()
                phantom_camera_3d.gd:1186 @ _look_at_target_tree_exiting()
```

This PR avoids it. Something similar may be needed for the 2D case above this one, but I can't test it now.

