### PR TITLE
Fix crash when active camera is in a scene that is freed

### DIFF
--- a/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
+++ b/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
@@ -750,9 +750,15 @@ func _physics_process(delta: float) -> void:
 
 func _tween_follow_checker(delta: float) -> void:
 	if _is_2d:
+		if not is_instance_valid(_active_pcam_2d):
+			return
+
 		_active_pcam_2d.process_logic(delta)
 		_active_pcam_2d_glob_transform = _active_pcam_2d.get_transform_output()
 	else:
+		if not is_instance_valid(_active_pcam_3d):
+			return
+
 		_active_pcam_3d.process_logic(delta)
 		_active_pcam_3d_glob_transform = _active_pcam_3d.get_transform_output()
 


### PR DESCRIPTION
This can happen if you have one scene that has the active pcam and then that scene is freed.
In my case, I had a loading screen with a `PhantomCamera3D` that gets freed and then replaced with the "real" scene.