### PR TITLE
Add an option to always process Phantom Camera on Idle ticks

### DIFF
--- a/addons/phantom_camera/plugin.gd
+++ b/addons/phantom_camera/plugin.gd
@@ -22,6 +22,7 @@ const PHANTOM_CAMERA_MANAGER: StringName = "PhantomCameraManager"
 var _settings_show_jitter_tips: String = "phantom_camera/tips/show_jitter_tips"
 var _settings_enable_editor_shortcut: String = "phantom_camera/general/enable_editor_shortcut"
 var _settings_editor_shortcut: String = "phantom_camera/general/editor_shortcut"
+var _settings_always_process_on_idle: String = "phantom_camera/general/always_process_on_idle"
 
 # 	TODO - Pending merge of https://github.com/godotengine/godot/pull/102889 - Should only support Godot version after the release that is featured in
 #var _editor_shortcut: Shortcut = Shortcut.new()
@@ -96,6 +97,16 @@ func _enter_tree() -> void:
 	})
 	ProjectSettings.set_initial_value(_settings_show_jitter_tips, true)
 	ProjectSettings.set_as_basic(_settings_show_jitter_tips, true)
+
+	## Setting to always process Phantom Camera on Idle updates
+	if not ProjectSettings.has_setting(_settings_always_process_on_idle):
+		ProjectSettings.set_setting(_settings_always_process_on_idle, false)
+	ProjectSettings.add_property_info({
+		"name": _settings_always_process_on_idle,
+		"type": TYPE_BOOL,
+	})
+	ProjectSettings.set_initial_value(_settings_always_process_on_idle, false)
+	ProjectSettings.set_as_basic(_settings_always_process_on_idle, false)
 
 
 # 	TODO - Pending merge of https://github.com/godotengine/godot/pull/102889 - Should only support Godot version after this release

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
@@ -944,6 +944,7 @@ func _check_physics_body(target: Node2D) -> void:
 	if target is PhysicsBody2D:
 		var show_jitter_tips := ProjectSettings.get_setting("phantom_camera/tips/show_jitter_tips")
 		var physics_interpolation_enabled := ProjectSettings.get_setting("physics/common/physics_interpolation")
+		var always_process_on_idle := ProjectSettings.get_setting("phantom_camera/general/always_process_on_idle")
 
 		## NOTE - Feature Toggle
 		if Engine.get_version_info().major == 4 and \
@@ -955,7 +956,7 @@ func _check_physics_body(target: Node2D) -> void:
 				print_rich("This tip can be disabled from within [code]Project Settings / Phantom Camera / Tips / Show Jitter Tips[/code]")
 			return
 			## NOTE - Only supported in Godot 4.3 or above
-		elif not physics_interpolation_enabled and show_jitter_tips == null: # Default value is null when referencing custom Project Setting
+		elif not physics_interpolation_enabled and show_jitter_tips == null and (not always_process_on_idle): # Default value is null when referencing custom Project Setting
 			printerr("Physics Interpolation is disabled in the Project Settings, recommend enabling it to smooth out physics-based camera movement")
 			print_rich("This tip can be disabled from within [code]Project Settings / Phantom Camera / Tips / Show Jitter Tips[/code]")
 		_follow_target_physics_based = true

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -1294,6 +1294,7 @@ func _check_physics_body(target: Node3D) -> void:
 	if target is PhysicsBody3D:
 		var show_jitter_tips := ProjectSettings.get_setting("phantom_camera/tips/show_jitter_tips")
 		var physics_interpolation_enabled := ProjectSettings.get_setting("physics/common/physics_interpolation")
+		var always_process_on_idle := ProjectSettings.get_setting("phantom_camera/general/always_process_on_idle")
 
 		## NOTE - Feature Toggle
 		if Engine.get_version_info().major == 4 and \
@@ -1305,7 +1306,7 @@ func _check_physics_body(target: Node3D) -> void:
 				print_rich("This tip can be disabled from within [code]Project Settings / Phantom Camera / Tips / Show Jitter Tips[/code]")
 			return
 		## NOTE - Only supported in Godot 4.4 or above
-		elif not physics_interpolation_enabled and show_jitter_tips == null: # Default value is null when referencing custom Project Setting
+		elif not physics_interpolation_enabled and show_jitter_tips == null and (not always_process_on_idle): # Default value is null when referencing custom Project Setting
 			printerr("Physics Interpolation is disabled in the Project Settings, recommend enabling it to smooth out physics-based camera movement")
 			print_rich("This tip can be disabled from within [code]Project Settings / Phantom Camera / Tips / Show Jitter Tips[/code]")
 		_follow_target_physics_based = true

--- a/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
+++ b/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
@@ -677,11 +677,13 @@ func _assign_new_active_pcam(pcam: Node) -> void:
 
 
 func _check_pcam_physics() -> void:
+	var always_process_on_idle := ProjectSettings.get_setting("phantom_camera/general/always_process_on_idle")
+
 	if _is_2d:
 		## NOTE - Only supported in Godot 4.3 or later
 		if Engine.get_version_info().major == 4 and \
 		Engine.get_version_info().minor >= 3:
-			if _active_pcam_2d.get_follow_target_physics_based():
+			if _active_pcam_2d.get_follow_target_physics_based() and (not always_process_on_idle):
 				_follow_target_physics_based = true
 				## TODO - Temporary solution to support Godot 4.2
 				## Remove line below and uncomment the following once Godot 4.3 is min verison.
@@ -707,7 +709,7 @@ func _check_pcam_physics() -> void:
 		## NOTE - Only supported in Godot 4.4 or later
 		if Engine.get_version_info().major == 4 and \
 		Engine.get_version_info().minor >= 4:
-			if get_tree().physics_interpolation or _active_pcam_3d.get_follow_target_physics_based():
+			if (get_tree().physics_interpolation or _active_pcam_3d.get_follow_target_physics_based()) and (not always_process_on_idle):
 				#if get_tree().physics_interpolation or _active_pcam_3d.get_follow_target_physics_based():
 				_follow_target_physics_based = true
 				## TODO - Temporary solution to support Godot 4.2


### PR DESCRIPTION
This change addresses an issue I've been encountering in #535, where I've enabled physics interpolation but still want to process Phantom Camera on idle updates. 

To address this, I've added an option called `always_process_on_idle`, which prevents Phantom Camera from switching to processing on physics updates. I've put this option in the Advanced Settings, as its a bit of a _**I know what I'm doing**_:tm: button.

Please let me know if there are any edits I should make, or if the logic should be restructured.