### PR TITLE
Scale up camera pyramid shape to avoid clipping

### DIFF
--- a/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
+++ b/addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd
@@ -509,8 +509,19 @@ func _assign_new_active_pcam(pcam: Node) -> void:
 					var pyramid_shape_data = Engine.get_singleton("PhysicsServer3D").call("shape_get_data",
 						camera_3d.get_pyramid_shape_rid()
 					)
+
+					# Expand each point by 0.1 units on X, Y, Z axes
+					var expanded_points := PackedVector3Array()
+					for point in pyramid_shape_data:
+						var expanded_point := Vector3(
+							point.x + (0.02 if point.x >= 0 else -0.02),
+							point.y + (0.02 if point.y >= 0 else -0.02),
+							point.z + (0.02 if point.z >= 0 else -0.02)
+						)
+						expanded_points.append(expanded_point)
+
 					var shape = ClassDB.instantiate("ConvexPolygonShape3D")
-					shape.points = pyramid_shape_data
+					shape.points = expanded_points
 					_active_pcam_3d.shape = shape
 
 		if not _active_pcam_3d.physics_target_changed.is_connected(_check_pcam_physics):


### PR DESCRIPTION
This scales up the default shape of the pyramid that's being used by spring arm to avoid some clipping issues.

## Before

Notice how at the edges of the screen, the camera clips through solid objects.

https://github.com/user-attachments/assets/ee33152c-7872-4001-bc90-12bd7a0abfa2


## After

Now, since the collision shape is _slightly_ bigger, it avoids the clipping.

https://github.com/user-attachments/assets/14632e2f-479c-43cd-9119-5721f034e12f


