### PR TITLE
Fix swapped types of Up and UpTarget in C#

### DIFF
--- a/addons/phantom_camera/scripts/phantom_camera/PhantomCamera3D.cs
+++ b/addons/phantom_camera/scripts/phantom_camera/PhantomCamera3D.cs
@@ -256,15 +256,15 @@ public class PhantomCamera3D : PhantomCamera
         set => Node3D.Call(MethodName.SetLookAtDampingValue, value);
     }
 
-    public Node3D Up
+    public Vector3 Up
     {
-        get => (Node3D)Node3D.Call(MethodName.GetUp);
+        get => (Vector3)Node3D.Call(MethodName.GetUp);
         set => Node3D.Call(MethodName.SetUp, value);
     }
 
-    public Vector3 UpTarget
+    public Node3D UpTarget
     {
-        get => (Vector3)Node3D.Call(MethodName.GetUpTarget);
+        get => (Node3D)Node3D.Call(MethodName.GetUpTarget);
         set => Node3D.Call(MethodName.SetUpTarget, value);
     }
 


### PR DESCRIPTION
Using the C# interface for phantom camera and realized the types of Up and UpTarget are swapped leading to an error when used. Only tested quickly on my own project, should stop it from throwing errors on use of these properties in C#.