### PR TITLE
C#: Remove unnecessary deconstructors used to disconnect signals

### DIFF
--- a/addons/phantom_camera/scripts/phantom_camera/PhantomCamera.cs
+++ b/addons/phantom_camera/scripts/phantom_camera/PhantomCamera.cs
@@ -31,14 +31,6 @@ public abstract class PhantomCamera
     public event IsTweeningEventHandler? IsTweening;
     public event TweenCompletedEventHandler? TweenCompleted;
 
-    private readonly Callable _callableBecameActive;
-    private readonly Callable _callableBecameInactive;
-    private readonly Callable _callableFollowTargetChanged;
-    private readonly Callable _callableDeadZoneChanged;
-    private readonly Callable _callableTweenStarted;
-    private readonly Callable _callableIsTweening;
-    private readonly Callable _callableTweenCompleted;
-
     public int Priority
     {
         get => (int)Node.Call(MethodName.GetPriority);
@@ -135,32 +127,21 @@ public abstract class PhantomCamera
     {
         Node = phantomCameraNode;
 
-        _callableBecameActive = Callable.From(() => BecameActive?.Invoke());
-        _callableBecameInactive = Callable.From(() => BecameInactive?.Invoke());
-        _callableFollowTargetChanged = Callable.From(() => FollowTargetChanged?.Invoke());
-        _callableDeadZoneChanged = Callable.From(() => DeadZoneChanged?.Invoke());
-        _callableTweenStarted = Callable.From(() => TweenStarted?.Invoke());
-        _callableIsTweening = Callable.From(() => IsTweening?.Invoke());
-        _callableTweenCompleted = Callable.From(() => TweenCompleted?.Invoke());
+        var callableBecameActive = Callable.From(() => BecameActive?.Invoke());
+        var callableBecameInactive = Callable.From(() => BecameInactive?.Invoke());
+        var callableFollowTargetChanged = Callable.From(() => FollowTargetChanged?.Invoke());
+        var callableDeadZoneChanged = Callable.From(() => DeadZoneChanged?.Invoke());
+        var callableTweenStarted = Callable.From(() => TweenStarted?.Invoke());
+        var callableIsTweening = Callable.From(() => IsTweening?.Invoke());
+        var callableTweenCompleted = Callable.From(() => TweenCompleted?.Invoke());
 
-        Node.Connect(SignalName.BecameActive, _callableBecameActive);
-        Node.Connect(SignalName.BecameInactive, _callableBecameInactive);
-        Node.Connect(SignalName.FollowTargetChanged, _callableFollowTargetChanged);
-        Node.Connect(SignalName.DeadZoneChanged, _callableDeadZoneChanged);
-        Node.Connect(SignalName.TweenStarted, _callableTweenStarted);
-        Node.Connect(SignalName.IsTweening, _callableIsTweening);
-        Node.Connect(SignalName.TweenCompleted, _callableTweenCompleted);
-    }
-
-    ~PhantomCamera()
-    {
-        Node.Disconnect(SignalName.BecameActive, _callableBecameActive);
-        Node.Disconnect(SignalName.BecameInactive, _callableBecameInactive);
-        Node.Disconnect(SignalName.FollowTargetChanged, _callableFollowTargetChanged);
-        Node.Disconnect(SignalName.DeadZoneChanged, _callableDeadZoneChanged);
-        Node.Disconnect(SignalName.TweenStarted, _callableTweenStarted);
-        Node.Disconnect(SignalName.IsTweening, _callableIsTweening);
-        Node.Disconnect(SignalName.TweenCompleted, _callableTweenCompleted);
+        Node.Connect(SignalName.BecameActive, callableBecameActive);
+        Node.Connect(SignalName.BecameInactive, callableBecameInactive);
+        Node.Connect(SignalName.FollowTargetChanged, callableFollowTargetChanged);
+        Node.Connect(SignalName.DeadZoneChanged, callableDeadZoneChanged);
+        Node.Connect(SignalName.TweenStarted, callableTweenStarted);
+        Node.Connect(SignalName.IsTweening, callableIsTweening);
+        Node.Connect(SignalName.TweenCompleted, callableTweenCompleted);
     }
 
     public static class MethodName

--- a/addons/phantom_camera/scripts/phantom_camera/PhantomCamera2D.cs
+++ b/addons/phantom_camera/scripts/phantom_camera/PhantomCamera2D.cs
@@ -55,10 +55,6 @@ public class PhantomCamera2D : PhantomCamera
     public event DeadZoneReachedEventHandler? DeadZoneReached;
     public event NoiseEmittedEventHandler? NoiseEmitted;
 
-    private readonly Callable _callableTweenInterrupted;
-    private readonly Callable _callableDeadZoneReached;
-    private readonly Callable _callableNoiseEmitted;
-
     public Node2D FollowTarget
     {
         get => (Node2D)Node2D.Call(PhantomCamera.MethodName.GetFollowTarget);
@@ -216,20 +212,13 @@ public class PhantomCamera2D : PhantomCamera
 
     public PhantomCamera2D(GodotObject phantomCameraNode) : base(phantomCameraNode)
     {
-        _callableTweenInterrupted = Callable.From<Node2D>(pCam => TweenInterrupted?.Invoke(pCam));
-        _callableDeadZoneReached = Callable.From((Vector2 side) => DeadZoneReached?.Invoke(side));
-        _callableNoiseEmitted = Callable.From((Transform2D output) => NoiseEmitted?.Invoke(output));
+        var callableTweenInterrupted = Callable.From<Node2D>(pCam => TweenInterrupted?.Invoke(pCam));
+        var callableDeadZoneReached = Callable.From((Vector2 side) => DeadZoneReached?.Invoke(side));
+        var callableNoiseEmitted = Callable.From((Transform2D output) => NoiseEmitted?.Invoke(output));
 
-        Node2D.Connect(SignalName.TweenInterrupted, _callableTweenInterrupted);
-        Node2D.Connect(SignalName.DeadZoneReached, _callableDeadZoneReached);
-        Node2D.Connect(SignalName.NoiseEmitted, _callableNoiseEmitted);
-    }
-
-    ~PhantomCamera2D()
-    {
-        Node2D.Disconnect(SignalName.TweenInterrupted, _callableTweenInterrupted);
-        Node2D.Disconnect(SignalName.DeadZoneReached, _callableDeadZoneReached);
-        Node2D.Disconnect(SignalName.NoiseEmitted, _callableNoiseEmitted);
+        Node2D.Connect(SignalName.TweenInterrupted, callableTweenInterrupted);
+        Node2D.Connect(SignalName.DeadZoneReached, callableDeadZoneReached);
+        Node2D.Connect(SignalName.NoiseEmitted, callableNoiseEmitted);
     }
 
     public void SetLimitTarget(TileMap tileMap)

--- a/addons/phantom_camera/scripts/phantom_camera/PhantomCamera3D.cs
+++ b/addons/phantom_camera/scripts/phantom_camera/PhantomCamera3D.cs
@@ -98,13 +98,6 @@ public class PhantomCamera3D : PhantomCamera
     public event TweenInterruptedEventHandler? TweenInterrupted;
     public event NoiseEmittedEventHandler? NoiseEmitted;
 
-    private readonly Callable _callableLookAtTargetChanged;
-    private readonly Callable _callableDeadZoneReached;
-    private readonly Callable _callableCamera3DResourceChanged;
-    private readonly Callable _callableCamera3DResourcePropertyChanged;
-    private readonly Callable _callableTweenInterrupted;
-    private readonly Callable _callableNoiseEmitted;
-
     public Node3D FollowTarget
     {
         get => (Node3D)Node3D.Call(PhantomCamera.MethodName.GetFollowTarget);
@@ -347,30 +340,20 @@ public class PhantomCamera3D : PhantomCamera
 
     public PhantomCamera3D(GodotObject phantomCamera3DNode) : base(phantomCamera3DNode)
     {
-        _callableLookAtTargetChanged = Callable.From(() => LookAtTargetChanged?.Invoke());
-        _callableDeadZoneReached = Callable.From(() => DeadZoneReached?.Invoke());
-        _callableCamera3DResourceChanged = Callable.From(() => Camera3DResourceChanged?.Invoke());
-        _callableCamera3DResourcePropertyChanged = Callable.From((StringName property, Variant value) =>
-        Camera3DResourcePropertyChanged?.Invoke(property, value));
-        _callableTweenInterrupted = Callable.From<Node3D>(pCam => TweenInterrupted?.Invoke(pCam));
-        _callableNoiseEmitted = Callable.From((Transform3D output) => NoiseEmitted?.Invoke(output));
+        var callableLookAtTargetChanged = Callable.From(() => LookAtTargetChanged?.Invoke());
+        var callableDeadZoneReached = Callable.From(() => DeadZoneReached?.Invoke());
+        var callableCamera3DResourceChanged = Callable.From(() => Camera3DResourceChanged?.Invoke());
+        var callableCamera3DResourcePropertyChanged = Callable.From((StringName property, Variant value) =>
+            Camera3DResourcePropertyChanged?.Invoke(property, value));
+        var callableTweenInterrupted = Callable.From<Node3D>(pCam => TweenInterrupted?.Invoke(pCam));
+        var callableNoiseEmitted = Callable.From((Transform3D output) => NoiseEmitted?.Invoke(output));
 
-        Node3D.Connect(SignalName.LookAtTargetChanged, _callableLookAtTargetChanged);
-        Node3D.Connect(PhantomCamera.SignalName.DeadZoneReached, _callableDeadZoneReached);
-        Node3D.Connect(SignalName.Camera3DResourceChanged, _callableCamera3DResourceChanged);
-        Node3D.Connect(SignalName.Camera3DResourcePropertyChanged, _callableCamera3DResourcePropertyChanged);
-        Node3D.Connect(PhantomCamera.SignalName.TweenInterrupted, _callableTweenInterrupted);
-        Node3D.Connect(PhantomCamera.SignalName.NoiseEmitted, _callableNoiseEmitted);
-    }
-
-    ~PhantomCamera3D()
-    {
-        Node3D.Disconnect(SignalName.LookAtTargetChanged, _callableLookAtTargetChanged);
-        Node3D.Disconnect(PhantomCamera.SignalName.DeadZoneReached, _callableDeadZoneReached);
-        Node3D.Disconnect(SignalName.Camera3DResourceChanged, _callableCamera3DResourceChanged);
-        Node3D.Disconnect(SignalName.Camera3DResourcePropertyChanged, _callableCamera3DResourcePropertyChanged);
-        Node3D.Disconnect(PhantomCamera.SignalName.TweenInterrupted, _callableTweenInterrupted);
-        Node3D.Disconnect(PhantomCamera.SignalName.NoiseEmitted, _callableNoiseEmitted);
+        Node3D.Connect(SignalName.LookAtTargetChanged, callableLookAtTargetChanged);
+        Node3D.Connect(PhantomCamera.SignalName.DeadZoneReached, callableDeadZoneReached);
+        Node3D.Connect(SignalName.Camera3DResourceChanged, callableCamera3DResourceChanged);
+        Node3D.Connect(SignalName.Camera3DResourcePropertyChanged, callableCamera3DResourcePropertyChanged);
+        Node3D.Connect(PhantomCamera.SignalName.TweenInterrupted, callableTweenInterrupted);
+        Node3D.Connect(PhantomCamera.SignalName.NoiseEmitted, callableNoiseEmitted);
     }
 
     public new static class MethodName

--- a/addons/phantom_camera/scripts/phantom_camera_host/PhantomCameraHost.cs
+++ b/addons/phantom_camera/scripts/phantom_camera_host/PhantomCameraHost.cs
@@ -27,17 +27,11 @@ public class PhantomCameraHost()
     {
         Node = node;
 
-        _callablePCamBecameActive = Callable.From<Node>(pCam => PCamBecameActive?.Invoke(pCam));
-        _callablePCamBecameInactive = Callable.From<Node>(pCam => PCamBecameInactive?.Invoke(pCam));
+        var callablePCamBecameActive = Callable.From<Node>(pCam => PCamBecameActive?.Invoke(pCam));
+        var callablePCamBecameInactive = Callable.From<Node>(pCam => PCamBecameInactive?.Invoke(pCam));
 
-        Node.Connect(SignalName.PCamBecameActive, _callablePCamBecameActive);
-        Node.Connect(SignalName.PCamBecameInactive, _callablePCamBecameInactive);
-    }
-
-    ~PhantomCameraHost()
-    {
-        Node.Disconnect(SignalName.PCamBecameActive, _callablePCamBecameActive);
-        Node.Disconnect(SignalName.PCamBecameInactive, _callablePCamBecameInactive);
+        Node.Connect(SignalName.PCamBecameActive, callablePCamBecameActive);
+        Node.Connect(SignalName.PCamBecameInactive, callablePCamBecameInactive);
     }
 
     public delegate void PCamBecameActiveEventHandler(Node pCam);
@@ -46,9 +40,6 @@ public class PhantomCameraHost()
     public event PCamBecameActiveEventHandler? PCamBecameActive;
     public event PCamBecameInactiveEventHandler? PCamBecameInactive;
 
-
-    private readonly Callable _callablePCamBecameActive;
-    private readonly Callable _callablePCamBecameInactive;
     // For when Godot becomes the minimum version
     // public InterpolationMode InterpolationMode
     // {


### PR DESCRIPTION
Signals automatically get disconnected when an Object is freed, so there is no need for this.

More specifically, this line disconnects them:
https://github.com/godotengine/godot/blob/825ef2387f87de1c350696886e6c50b039204cef/core/object/object.cpp#L2311

Closes #565 