### PR TITLE
C#: Use StringName instead of string for PropertyName, MethodName and SignalName

### DIFF
--- a/addons/phantom_camera/scripts/managers/PhantomCameraManager.cs
+++ b/addons/phantom_camera/scripts/managers/PhantomCameraManager.cs
@@ -29,8 +29,8 @@ public static class PhantomCameraManager
 
     public static class MethodName
     {
-        public const string GetPhantomCamera2Ds = "get_phantom_camera_2ds";
-        public const string GetPhantomCamera3Ds = "get_phantom_camera_3ds";
-        public const string GetPhantomCameraHosts = "get_phantom_camera_hosts";
+        public static readonly StringName GetPhantomCamera2Ds = new("get_phantom_camera_2ds");
+        public static readonly StringName GetPhantomCamera3Ds = new("get_phantom_camera_3ds");
+        public static readonly StringName GetPhantomCameraHosts = new("get_phantom_camera_hosts");
     }
 }

--- a/addons/phantom_camera/scripts/phantom_camera/PhantomCamera.cs
+++ b/addons/phantom_camera/scripts/phantom_camera/PhantomCamera.cs
@@ -146,89 +146,89 @@ public abstract class PhantomCamera
 
     public static class MethodName
     {
-        public const string GetFollowMode = "get_follow_mode";
-        public const string IsActive = "is_active";
+        public static readonly StringName GetFollowMode = new("get_follow_mode");
+        public static readonly StringName IsActive = new("is_active");
 
-        public const string GetPriority = "get_priority";
-        public const string SetPriority = "set_priority";
+        public static readonly StringName GetPriority = new("get_priority");
+        public static readonly StringName SetPriority = new("set_priority");
 
-        public const string IsFollowing = "is_following";
+        public static readonly StringName IsFollowing = new("is_following");
 
-        public const string GetFollowTarget = "get_follow_target";
-        public const string SetFollowTarget = "set_follow_target";
+        public static readonly StringName GetFollowTarget = new("get_follow_target");
+        public static readonly StringName SetFollowTarget = new("set_follow_target");
 
-        public const string GetFollowTargets = "get_follow_targets";
-        public const string SetFollowTargets = "set_follow_targets";
+        public static readonly StringName GetFollowTargets = new("get_follow_targets");
+        public static readonly StringName SetFollowTargets = new("set_follow_targets");
 
-        public const string TeleportPosition = "teleport_position";
+        public static readonly StringName TeleportPosition = new("teleport_position");
 
-        public const string AppendFollowTargets = "append_follow_targets";
-        public const string AppendFollowTargetsArray = "append_follow_targets_array";
-        public const string EraseFollowTargets = "erase_follow_targets";
+        public static readonly StringName AppendFollowTargets = new("append_follow_targets");
+        public static readonly StringName AppendFollowTargetsArray = new("append_follow_targets_array");
+        public static readonly StringName EraseFollowTargets = new("erase_follow_targets");
 
-        public const string GetFollowPath = "get_follow_path";
-        public const string SetFollowPath = "set_follow_path";
+        public static readonly StringName GetFollowPath = new("get_follow_path");
+        public static readonly StringName SetFollowPath = new("set_follow_path");
 
-        public const string GetFollowOffset = "get_follow_offset";
-        public const string SetFollowOffset = "set_follow_offset";
+        public static readonly StringName GetFollowOffset = new("get_follow_offset");
+        public static readonly StringName SetFollowOffset = new("set_follow_offset");
 
-        public const string GetFollowDamping = "get_follow_damping";
-        public const string SetFollowDamping = "set_follow_damping";
+        public static readonly StringName GetFollowDamping = new("get_follow_damping");
+        public static readonly StringName SetFollowDamping = new("set_follow_damping");
 
-        public const string GetFollowDampingValue = "get_follow_damping_value";
-        public const string SetFollowDampingValue = "set_follow_damping_value";
+        public static readonly StringName GetFollowDampingValue = new("get_follow_damping_value");
+        public static readonly StringName SetFollowDampingValue = new("set_follow_damping_value");
 
-        public const string GetFollowAxisLock = "get_follow_axis_lock";
-        public const string SetFollowAxisLock = "set_follow_axis_lock";
+        public static readonly StringName GetFollowAxisLock = new("get_follow_axis_lock");
+        public static readonly StringName SetFollowAxisLock = new("set_follow_axis_lock");
 
-        public const string GetTweenResource = "get_tween_resource";
-        public const string SetTweenResource = "set_tween_resource";
+        public static readonly StringName GetTweenResource = new("get_tween_resource");
+        public static readonly StringName SetTweenResource = new("set_tween_resource");
 
-        public const string GetTweenSkip = "get_tween_skip";
-        public const string SetTweenSkip = "set_tween_skip";
+        public static readonly StringName GetTweenSkip = new("get_tween_skip");
+        public static readonly StringName SetTweenSkip = new("set_tween_skip");
 
-        public const string GetTweenDuration = "get_tween_duration";
-        public const string SetTweenDuration = "set_tween_duration";
+        public static readonly StringName GetTweenDuration = new("get_tween_duration");
+        public static readonly StringName SetTweenDuration = new("set_tween_duration");
 
-        public const string GetTweenTransition = "get_tween_transition";
-        public const string SetTweenTransition = "set_tween_transition";
+        public static readonly StringName GetTweenTransition = new("get_tween_transition");
+        public static readonly StringName SetTweenTransition = new("set_tween_transition");
 
-        public const string GetTweenEase = "get_tween_ease";
-        public const string SetTweenEase = "set_tween_ease";
+        public static readonly StringName GetTweenEase = new("get_tween_ease");
+        public static readonly StringName SetTweenEase = new("set_tween_ease");
 
-        public const string GetTweenOnLoad = "get_tween_on_load";
-        public const string SetTweenOnLoad = "set_tween_on_load";
+        public static readonly StringName GetTweenOnLoad = new("get_tween_on_load");
+        public static readonly StringName SetTweenOnLoad = new("set_tween_on_load");
 
-        public const string GetInactiveUpdateMode = "get_inactive_update_mode";
-        public const string SetInactiveUpdateMode = "set_inactive_update_mode";
+        public static readonly StringName GetInactiveUpdateMode = new("get_inactive_update_mode");
+        public static readonly StringName SetInactiveUpdateMode = new("set_inactive_update_mode");
 
-        public const string GetHostLayers = "get_host_layers";
-        public const string SetHostLayers = "set_host_layers";
-        public const string SetHostLayersValue = "set_host_layers_value";
+        public static readonly StringName GetHostLayers = new("get_host_layers");
+        public static readonly StringName SetHostLayers = new("set_host_layers");
+        public static readonly StringName SetHostLayersValue = new("set_host_layers_value");
 
-        public const string GetNoiseEmitterLayer = "get_noise_emitter_layer";
-        public const string SetNoiseEmitterLayer = "set_noise_emitter_layer";
+        public static readonly StringName GetNoiseEmitterLayer = new("get_noise_emitter_layer");
+        public static readonly StringName SetNoiseEmitterLayer = new("set_noise_emitter_layer");
 
-        public const string EmitNoise = "emit_noise";
+        public static readonly StringName EmitNoise = new("emit_noise");
     }
 
     public static class PropertyName
     {
-        public const string DeadZoneWidth = "dead_zone_width";
-        public const string DeadZoneHeight = "dead_zone_height";
+        public static readonly StringName DeadZoneWidth = new("dead_zone_width");
+        public static readonly StringName DeadZoneHeight = new("dead_zone_height");
     }
 
     public static class SignalName
     {
-        public const string BecameActive = "became_active";
-        public const string BecameInactive = "became_inactive";
-        public const string FollowTargetChanged = "follow_target_changed";
-        public const string DeadZoneChanged = "dead_zone_changed";
-        public const string DeadZoneReached = "dead_zone_reached";
-        public const string TweenStarted = "tween_started";
-        public const string IsTweening = "is_tweening";
-        public const string TweenCompleted = "tween_completed";
-        public const string TweenInterrupted = "tween_interrupted";
-        public const string NoiseEmitted = "noise_emitted";
+        public static readonly StringName BecameActive = new("became_active");
+        public static readonly StringName BecameInactive = new("became_inactive");
+        public static readonly StringName FollowTargetChanged = new("follow_target_changed");
+        public static readonly StringName DeadZoneChanged = new("dead_zone_changed");
+        public static readonly StringName DeadZoneReached = new("dead_zone_reached");
+        public static readonly StringName TweenStarted = new("tween_started");
+        public static readonly StringName IsTweening = new("is_tweening");
+        public static readonly StringName TweenCompleted = new("tween_completed");
+        public static readonly StringName TweenInterrupted = new("tween_interrupted");
+        public static readonly StringName NoiseEmitted = new("noise_emitted");
     }
 }

--- a/addons/phantom_camera/scripts/phantom_camera/PhantomCamera2D.cs
+++ b/addons/phantom_camera/scripts/phantom_camera/PhantomCamera2D.cs
@@ -254,64 +254,64 @@ public class PhantomCamera2D : PhantomCamera
 
     public new static class MethodName
     {
-        public const string GetZoom = "get_zoom";
-        public const string SetZoom = "set_zoom";
+        public static readonly StringName GetZoom = new("get_zoom");
+        public static readonly StringName SetZoom = new("set_zoom");
 
-        public const string GetSnapToPixel = "get_snap_to_pixel";
-        public const string SetSnapToPixel = "set_snap_to_pixel";
+        public static readonly StringName GetSnapToPixel = new("get_snap_to_pixel");
+        public static readonly StringName SetSnapToPixel = new("set_snap_to_pixel");
 
-        public const string GetRotateWithTarget = "get_rotate_with_target";
-        public const string SetRotateWithTarget = "set_rotate_with_target";
+        public static readonly StringName GetRotateWithTarget = new("get_rotate_with_target");
+        public static readonly StringName SetRotateWithTarget = new("set_rotate_with_target");
 
-        public const string GetRotationOffset = "get_rotation_offset";
-        public const string SetRotationOffset = "set_rotation_offset";
+        public static readonly StringName GetRotationOffset = new("get_rotation_offset");
+        public static readonly StringName SetRotationOffset = new("set_rotation_offset");
 
-        public const string GetRotationDamping = "get_rotation_damping";
-        public const string SetRotationDamping = "set_rotation_damping";
+        public static readonly StringName GetRotationDamping = new("get_rotation_damping");
+        public static readonly StringName SetRotationDamping = new("set_rotation_damping");
 
-        public const string GetRotationDampingValue = "get_rotation_damping_value";
-        public const string SetRotationDampingValue = "set_rotation_damping_value";
+        public static readonly StringName GetRotationDampingValue = new("get_rotation_damping_value");
+        public static readonly StringName SetRotationDampingValue = new("set_rotation_damping_value");
 
-        public const string GetLimit = "get_limit";
-        public const string SetLimit = "set_limit";
+        public static readonly StringName GetLimit = new("get_limit");
+        public static readonly StringName SetLimit = new("set_limit");
 
-        public const string GetLimitLeft = "get_limit_left";
-        public const string SetLimitLeft = "set_limit_left";
+        public static readonly StringName GetLimitLeft = new("get_limit_left");
+        public static readonly StringName SetLimitLeft = new("set_limit_left");
 
-        public const string GetLimitTop = "get_limit_top";
-        public const string SetLimitTop = "set_limit_top";
+        public static readonly StringName GetLimitTop = new("get_limit_top");
+        public static readonly StringName SetLimitTop = new("set_limit_top");
 
-        public const string GetLimitRight = "get_limit_right";
-        public const string SetLimitRight = "set_limit_right";
+        public static readonly StringName GetLimitRight = new("get_limit_right");
+        public static readonly StringName SetLimitRight = new("set_limit_right");
 
-        public const string GetLimitBottom = "get_limit_bottom";
-        public const string SetLimitBottom = "set_limit_bottom";
+        public static readonly StringName GetLimitBottom = new("get_limit_bottom");
+        public static readonly StringName SetLimitBottom = new("set_limit_bottom");
 
-        public const string GetLimitTarget = "get_limit_target";
-        public const string SetLimitTarget = "set_limit_target";
+        public static readonly StringName GetLimitTarget = new("get_limit_target");
+        public static readonly StringName SetLimitTarget = new("set_limit_target");
 
-        public const string GetLimitMargin = "get_limit_margin";
-        public const string SetLimitMargin = "set_limit_margin";
+        public static readonly StringName GetLimitMargin = new("get_limit_margin");
+        public static readonly StringName SetLimitMargin = new("set_limit_margin");
 
-        public const string GetAutoZoom = "get_auto_zoom";
-        public const string SetAutoZoom = "set_auto_zoom";
+        public static readonly StringName GetAutoZoom = new("get_auto_zoom");
+        public static readonly StringName SetAutoZoom = new("set_auto_zoom");
 
-        public const string GetAutoZoomMin = "get_auto_zoom_min";
-        public const string SetAutoZoomMin = "set_auto_zoom_min";
+        public static readonly StringName GetAutoZoomMin = new("get_auto_zoom_min");
+        public static readonly StringName SetAutoZoomMin = new("set_auto_zoom_min");
 
-        public const string GetAutoZoomMax = "get_auto_zoom_max";
-        public const string SetAutoZoomMax = "set_auto_zoom_max";
+        public static readonly StringName GetAutoZoomMax = new("get_auto_zoom_max");
+        public static readonly StringName SetAutoZoomMax = new("set_auto_zoom_max");
 
-        public const string GetAutoZoomMargin = "get_auto_zoom_margin";
-        public const string SetAutoZoomMargin = "set_auto_zoom_margin";
+        public static readonly StringName GetAutoZoomMargin = new("get_auto_zoom_margin");
+        public static readonly StringName SetAutoZoomMargin = new("set_auto_zoom_margin");
 
-        public const string GetNoise = "get_noise";
-        public const string SetNoise = "set_noise";
+        public static readonly StringName GetNoise = new("get_noise");
+        public static readonly StringName SetNoise = new("set_noise");
     }
 
     public new static class PropertyName
     {
-        public const string DrawLimits = "draw_limits";
+        public static readonly StringName DrawLimits = new("draw_limits");
     }
 }
 

--- a/addons/phantom_camera/scripts/phantom_camera/PhantomCamera3D.cs
+++ b/addons/phantom_camera/scripts/phantom_camera/PhantomCamera3D.cs
@@ -358,119 +358,119 @@ public class PhantomCamera3D : PhantomCamera
 
     public new static class MethodName
     {
-        public const string GetLookAtMode = "get_look_at_mode";
+        public static readonly StringName GetLookAtMode = new("get_look_at_mode");
 
-        public const string GetCamera3DResource = "get_camera_3d_resource";
-        public const string SetCamera3DResource = "set_camera_3d_resource";
+        public static readonly StringName GetCamera3DResource = new("get_camera_3d_resource");
+        public static readonly StringName SetCamera3DResource = new("set_camera_3d_resource");
 
-        public const string GetThirdPersonRotation = "get_third_person_rotation";
-        public const string SetThirdPersonRotation = "set_third_person_rotation";
+        public static readonly StringName GetThirdPersonRotation = new("get_third_person_rotation");
+        public static readonly StringName SetThirdPersonRotation = new("set_third_person_rotation");
 
-        public const string GetThirdPersonRotationDegrees = "get_third_person_rotation_degrees";
-        public const string SetThirdPersonRotationDegrees = "set_third_person_rotation_degrees";
+        public static readonly StringName GetThirdPersonRotationDegrees = new("get_third_person_rotation_degrees");
+        public static readonly StringName SetThirdPersonRotationDegrees = new("set_third_person_rotation_degrees");
 
-        public const string GetThirdPersonQuaternion = "get_third_person_quaternion";
-        public const string SetThirdPersonQuaternion = "set_third_person_quaternion";
+        public static readonly StringName GetThirdPersonQuaternion = new("get_third_person_quaternion");
+        public static readonly StringName SetThirdPersonQuaternion = new("set_third_person_quaternion");
 
-        public const string GetVerticalRotationOffset = "get_vertical_rotation_offset";
-        public const string SetVerticalRotationOffset = "set_vertical_rotation_offset";
+        public static readonly StringName GetVerticalRotationOffset = new("get_vertical_rotation_offset");
+        public static readonly StringName SetVerticalRotationOffset = new("set_vertical_rotation_offset");
 
-        public const string GetHorizontalRotationOffset = "get_horizontal_rotation_offset";
-        public const string SetHorizontalRotationOffset = "set_horizontal_rotation_offset";
+        public static readonly StringName GetHorizontalRotationOffset = new("get_horizontal_rotation_offset");
+        public static readonly StringName SetHorizontalRotationOffset = new("set_horizontal_rotation_offset");
 
-        public const string GetSpringLength = "get_spring_length";
-        public const string SetSpringLength = "set_spring_length";
+        public static readonly StringName GetSpringLength = new("get_spring_length");
+        public static readonly StringName SetSpringLength = new("set_spring_length");
 
-        public const string GetFollowDistance = "get_follow_distance";
-        public const string SetFollowDistance = "set_follow_distance";
+        public static readonly StringName GetFollowDistance = new("get_follow_distance");
+        public static readonly StringName SetFollowDistance = new("set_follow_distance");
 
-        public const string GetAutoFollowDistance = "get_auto_follow_distance";
-        public const string SetAutoFollowDistance = "set_auto_follow_distance";
+        public static readonly StringName GetAutoFollowDistance = new("get_auto_follow_distance");
+        public static readonly StringName SetAutoFollowDistance = new("set_auto_follow_distance");
 
-        public const string GetAutoFollowDistanceMin = "get_auto_follow_distance_min";
-        public const string SetAutoFollowDistanceMin = "set_auto_follow_distance_min";
+        public static readonly StringName GetAutoFollowDistanceMin = new("get_auto_follow_distance_min");
+        public static readonly StringName SetAutoFollowDistanceMin = new("set_auto_follow_distance_min");
 
-        public const string GetAutoFollowDistanceMax = "get_auto_follow_distance_max";
-        public const string SetAutoFollowDistanceMax = "set_auto_follow_distance_max";
+        public static readonly StringName GetAutoFollowDistanceMax = new("get_auto_follow_distance_max");
+        public static readonly StringName SetAutoFollowDistanceMax = new("set_auto_follow_distance_max");
 
-        public const string GetAutoFollowDistanceDivisor = "get_auto_follow_distance_divisor";
-        public const string SetAutoFollowDistanceDivisor = "set_auto_follow_distance_divisor";
+        public static readonly StringName GetAutoFollowDistanceDivisor = new("get_auto_follow_distance_divisor");
+        public static readonly StringName SetAutoFollowDistanceDivisor = new("set_auto_follow_distance_divisor");
 
-        public const string GetLookAtTarget = "get_look_at_target";
-        public const string SetLookAtTarget = "set_look_at_target";
+        public static readonly StringName GetLookAtTarget = new("get_look_at_target");
+        public static readonly StringName SetLookAtTarget = new("set_look_at_target");
 
-        public const string GetLookAtTargets = "get_look_at_targets";
-        public const string SetLookAtTargets = "set_look_at_targets";
+        public static readonly StringName GetLookAtTargets = new("get_look_at_targets");
+        public static readonly StringName SetLookAtTargets = new("set_look_at_targets");
 
-        public const string IsLooking = "is_looking";
+        public static readonly StringName IsLooking = new("is_looking");
 
-        public const string GetUp = "get_up";
-        public const string SetUp = "set_up";
+        public static readonly StringName GetUp = new("get_up");
+        public static readonly StringName SetUp = new("set_up");
 
-        public const string GetUpTarget = "get_up_target";
-        public const string SetUpTarget = "set_up_target";
+        public static readonly StringName GetUpTarget = new("get_up_target");
+        public static readonly StringName SetUpTarget = new("set_up_target");
 
-        public const string GetCollisionMask = "get_collision_mask";
-        public const string SetCollisionMask = "set_collision_mask";
+        public static readonly StringName GetCollisionMask = new("get_collision_mask");
+        public static readonly StringName SetCollisionMask = new("set_collision_mask");
 
-        public const string SetCollisionMaskValue = "set_collision_mask_value";
+        public static readonly StringName SetCollisionMaskValue = new("set_collision_mask_value");
 
-        public const string GetShape = "get_shape";
-        public const string SetShape = "set_shape";
+        public static readonly StringName GetShape = new("get_shape");
+        public static readonly StringName SetShape = new("set_shape");
 
-        public const string GetMargin = "get_margin";
-        public const string SetMargin = "set_margin";
+        public static readonly StringName GetMargin = new("get_margin");
+        public static readonly StringName SetMargin = new("set_margin");
 
-        public const string GetLookAtOffset = "get_look_at_offset";
-        public const string SetLookAtOffset = "set_look_at_offset";
+        public static readonly StringName GetLookAtOffset = new("get_look_at_offset");
+        public static readonly StringName SetLookAtOffset = new("set_look_at_offset");
 
-        public const string GetLookAtDamping = "get_look_at_damping";
-        public const string SetLookAtDamping = "set_look_at_damping";
+        public static readonly StringName GetLookAtDamping = new("get_look_at_damping");
+        public static readonly StringName SetLookAtDamping = new("set_look_at_damping");
 
-        public const string GetLookAtDampingValue = "get_look_at_damping_value";
-        public const string SetLookAtDampingValue = "set_look_at_damping_value";
+        public static readonly StringName GetLookAtDampingValue = new("get_look_at_damping_value");
+        public static readonly StringName SetLookAtDampingValue = new("set_look_at_damping_value");
 
-        public const string GetCullMask = "get_cull_mask";
-        public const string SetCullMask = "set_cull_mask";
+        public static readonly StringName GetCullMask = new("get_cull_mask");
+        public static readonly StringName SetCullMask = new("set_cull_mask");
 
-        public const string GetHOffset = "get_h_offset";
-        public const string SetHOffset = "set_h_offset";
+        public static readonly StringName GetHOffset = new("get_h_offset");
+        public static readonly StringName SetHOffset = new("set_h_offset");
 
-        public const string GetVOffset = "get_v_offset";
-        public const string SetVOffset = "set_v_offset";
+        public static readonly StringName GetVOffset = new("get_v_offset");
+        public static readonly StringName SetVOffset = new("set_v_offset");
 
-        public const string GetProjection = "get_projection";
-        public const string SetProjection = "set_projection";
+        public static readonly StringName GetProjection = new("get_projection");
+        public static readonly StringName SetProjection = new("set_projection");
 
-        public const string GetFov = "get_fov";
-        public const string SetFov = "set_fov";
+        public static readonly StringName GetFov = new("get_fov");
+        public static readonly StringName SetFov = new("set_fov");
 
-        public const string GetSize = "get_size";
-        public const string SetSize = "set_size";
+        public static readonly StringName GetSize = new("get_size");
+        public static readonly StringName SetSize = new("set_size");
 
-        public const string GetFrustumOffset = "get_frustum_offset";
-        public const string SetFrustumOffset = "set_frustum_offset";
+        public static readonly StringName GetFrustumOffset = new("get_frustum_offset");
+        public static readonly StringName SetFrustumOffset = new("set_frustum_offset");
 
-        public const string GetFar = "get_far";
-        public const string SetFar = "set_far";
+        public static readonly StringName GetFar = new("get_far");
+        public static readonly StringName SetFar = new("set_far");
 
-        public const string GetNear = "get_near";
-        public const string SetNear = "set_near";
+        public static readonly StringName GetNear = new("get_near");
+        public static readonly StringName SetNear = new("set_near");
 
-        public const string GetEnvironment = "get_environment";
-        public const string SetEnvironment = "set_environment";
+        public static readonly StringName GetEnvironment = new("get_environment");
+        public static readonly StringName SetEnvironment = new("set_environment");
 
-        public const string GetAttributes = "get_attributes";
-        public const string SetAttributes = "set_attributes";
+        public static readonly StringName GetAttributes = new("get_attributes");
+        public static readonly StringName SetAttributes = new("set_attributes");
 
-        public const string GetNoise = "get_noise";
-        public const string SetNoise = "set_noise";
+        public static readonly StringName GetNoise = new("get_noise");
+        public static readonly StringName SetNoise = new("set_noise");
     }
 
     public new static class SignalName
     {
-        public const string LookAtTargetChanged = "look_at_target_changed";
-        public const string Camera3DResourceChanged = "camera_3d_resource_changed";
-        public const string Camera3DResourcePropertyChanged = "camera_3d_resource_property_changed";
+        public static readonly StringName LookAtTargetChanged = new("look_at_target_changed");
+        public static readonly StringName Camera3DResourceChanged = new("camera_3d_resource_changed");
+        public static readonly StringName Camera3DResourcePropertyChanged = new("camera_3d_resource_property_changed");
     }
 }

--- a/addons/phantom_camera/scripts/phantom_camera/PhantomCameraNoiseEmitter2D.cs
+++ b/addons/phantom_camera/scripts/phantom_camera/PhantomCameraNoiseEmitter2D.cs
@@ -55,29 +55,29 @@ public class PhantomCameraNoiseEmitter2D(GodotObject node)
 
     public static class MethodName
     {
-        public const string GetNoise = "get_noise";
-        public const string SetNoise = "set_noise";
+        public static readonly StringName GetNoise = new("get_noise");
+        public static readonly StringName SetNoise = new("set_noise");
 
-        public const string GetContinuous = "get_continuous";
-        public const string SetContinuous = "set_continuous";
+        public static readonly StringName GetContinuous = new("get_continuous");
+        public static readonly StringName SetContinuous = new("set_continuous");
 
-        public const string GetGrowthTime = "get_growth_time";
-        public const string SetGrowthTime = "set_growth_time";
+        public static readonly StringName GetGrowthTime = new("get_growth_time");
+        public static readonly StringName SetGrowthTime = new("set_growth_time");
 
-        public const string GetDuration = "get_duration";
-        public const string SetDuration = "set_duration";
+        public static readonly StringName GetDuration = new("get_duration");
+        public static readonly StringName SetDuration = new("set_duration");
 
-        public const string GetDecayTime = "get_decay_time";
-        public const string SetDecayTime = "set_decay_time";
+        public static readonly StringName GetDecayTime = new("get_decay_time");
+        public static readonly StringName SetDecayTime = new("set_decay_time");
 
-        public const string GetNoiseEmitterLayer = "get_noise_emitter_layer";
-        public const string SetNoiseEmitterLayer = "set_noise_emitter_layer";
+        public static readonly StringName GetNoiseEmitterLayer = new("get_noise_emitter_layer");
+        public static readonly StringName SetNoiseEmitterLayer = new("set_noise_emitter_layer");
 
-        public const string SetNoiseEmitterLayerValue = "set_noise_emitter_layer_value";
+        public static readonly StringName SetNoiseEmitterLayerValue = new("set_noise_emitter_layer_value");
 
-        public const string Emit = "emit";
-        public const string IsEmitting = "is_emitting";
-        public const string Stop = "stop";
-        public const string Toggle = "toggle";
+        public static readonly StringName Emit = new("emit");
+        public static readonly StringName IsEmitting = new("is_emitting");
+        public static readonly StringName Stop = new("stop");
+        public static readonly StringName Toggle = new("toggle");
     }
 }

--- a/addons/phantom_camera/scripts/phantom_camera/PhantomCameraNoiseEmitter3D.cs
+++ b/addons/phantom_camera/scripts/phantom_camera/PhantomCameraNoiseEmitter3D.cs
@@ -55,29 +55,29 @@ public class PhantomCameraNoiseEmitter3D(GodotObject node)
 
     public static class MethodName
     {
-        public const string GetNoise = "get_noise";
-        public const string SetNoise = "set_noise";
+        public static readonly StringName GetNoise = new("get_noise");
+        public static readonly StringName SetNoise = new("set_noise");
 
-        public const string GetContinuous = "get_continuous";
-        public const string SetContinuous = "set_continuous";
+        public static readonly StringName GetContinuous = new("get_continuous");
+        public static readonly StringName SetContinuous = new("set_continuous");
 
-        public const string GetGrowthTime = "get_growth_time";
-        public const string SetGrowthTime = "set_growth_time";
+        public static readonly StringName GetGrowthTime = new("get_growth_time");
+        public static readonly StringName SetGrowthTime = new("set_growth_time");
 
-        public const string GetDuration = "get_duration";
-        public const string SetDuration = "set_duration";
+        public static readonly StringName GetDuration = new("get_duration");
+        public static readonly StringName SetDuration = new("set_duration");
 
-        public const string GetDecayTime = "get_decay_time";
-        public const string SetDecayTime = "set_decay_time";
+        public static readonly StringName GetDecayTime = new("get_decay_time");
+        public static readonly StringName SetDecayTime = new("set_decay_time");
 
-        public const string GetNoiseEmitterLayer = "get_noise_emitter_layer";
-        public const string SetNoiseEmitterLayer = "set_noise_emitter_layer";
+        public static readonly StringName GetNoiseEmitterLayer = new("get_noise_emitter_layer");
+        public static readonly StringName SetNoiseEmitterLayer = new("set_noise_emitter_layer");
 
-        public const string SetNoiseEmitterLayerValue = "set_noise_emitter_layer_value";
+        public static readonly StringName SetNoiseEmitterLayerValue = new("set_noise_emitter_layer_value");
 
-        public const string Emit = "emit";
-        public const string IsEmitting = "is_emitting";
-        public const string Stop = "stop";
-        public const string Toggle = "toggle";
+        public static readonly StringName Emit = new("emit");
+        public static readonly StringName IsEmitting = new("is_emitting");
+        public static readonly StringName Stop = new("stop");
+        public static readonly StringName Toggle = new("toggle");
     }
 }

--- a/addons/phantom_camera/scripts/phantom_camera_host/PhantomCameraHost.cs
+++ b/addons/phantom_camera/scripts/phantom_camera_host/PhantomCameraHost.cs
@@ -86,24 +86,24 @@ public class PhantomCameraHost()
 
     public static class PropertyName
     {
-        public const string Camera2D = "camera_2d";
-        public const string Camera3D = "camera_3d";
+        public static readonly StringName Camera2D = new("camera_2d");
+        public static readonly StringName Camera3D = new("camera_3d");
     }
 
     public static class MethodName
     {
-        public const string GetActivePhantomCamera = "get_active_pcam";
-        public const string GetTriggerPhantomCameraTween = "get_trigger_pcam_tween";
+        public static readonly StringName GetActivePhantomCamera = new("get_active_pcam");
+        public static readonly StringName GetTriggerPhantomCameraTween = new("get_trigger_pcam_tween");
 
-        public const string GetInterpolationMode = "get_interpolation_mode";
-        public const string SetInterpolationMode = "set_interpolation_mode";
+        public static readonly StringName GetInterpolationMode = new("get_interpolation_mode");
+        public static readonly StringName SetInterpolationMode = new("set_interpolation_mode");
 
-        public const string SetHostLayersValue = "set_host_layers_value";
+        public static readonly StringName SetHostLayersValue = new("set_host_layers_value");
     }
 
     public static class SignalName
     {
-        public const string PCamBecameActive = "pcam_became_active";
-        public const string PCamBecameInactive = "pcam_became_inactive";
+        public static readonly StringName PCamBecameActive = new("pcam_became_active");
+        public static readonly StringName PCamBecameInactive = new("pcam_became_inactive");
     }
 }

--- a/addons/phantom_camera/scripts/resources/Camera3DResource.cs
+++ b/addons/phantom_camera/scripts/resources/Camera3DResource.cs
@@ -83,35 +83,35 @@ public class Camera3DResource(Resource resource)
 
     public static class MethodName
     {
-        public const string GetKeepAspect = "get_keep_aspect";
-        public const string SetKeepAspect = "set_keep_aspect";
+        public static readonly StringName GetKeepAspect = new("get_keep_aspect");
+        public static readonly StringName SetKeepAspect = new("set_keep_aspect");
 
-        public const string GetCullMask = "get_cull_mask";
-        public const string SetCullMask = "set_cull_mask";
-        public const string SetCullMaskValue = "set_cull_mask_value";
+        public static readonly StringName GetCullMask = new("get_cull_mask");
+        public static readonly StringName SetCullMask = new("set_cull_mask");
+        public static readonly StringName SetCullMaskValue = new("set_cull_mask_value");
 
-        public const string GetHOffset = "get_h_offset";
-        public const string SetHOffset = "set_h_offset";
+        public static readonly StringName GetHOffset = new("get_h_offset");
+        public static readonly StringName SetHOffset = new("set_h_offset");
 
-        public const string GetVOffset = "get_v_offset";
-        public const string SetVOffset = "set_v_offset";
+        public static readonly StringName GetVOffset = new("get_v_offset");
+        public static readonly StringName SetVOffset = new("set_v_offset");
 
-        public const string GetProjection = "get_projection";
-        public const string SetProjection = "set_projection";
+        public static readonly StringName GetProjection = new("get_projection");
+        public static readonly StringName SetProjection = new("set_projection");
 
-        public const string GetFov = "get_fov";
-        public const string SetFov = "set_fov";
+        public static readonly StringName GetFov = new("get_fov");
+        public static readonly StringName SetFov = new("set_fov");
 
-        public const string GetSize = "get_size";
-        public const string SetSize = "set_size";
+        public static readonly StringName GetSize = new("get_size");
+        public static readonly StringName SetSize = new("set_size");
 
-        public const string GetFrustumOffset = "get_frustum_offset";
-        public const string SetFrustumOffset = "set_frustum_offset";
+        public static readonly StringName GetFrustumOffset = new("get_frustum_offset");
+        public static readonly StringName SetFrustumOffset = new("set_frustum_offset");
 
-        public const string GetNear = "get_near";
-        public const string SetNear = "set_near";
+        public static readonly StringName GetNear = new("get_near");
+        public static readonly StringName SetNear = new("set_near");
 
-        public const string GetFar = "get_far";
-        public const string SetFar = "set_far";
+        public static readonly StringName GetFar = new("get_far");
+        public static readonly StringName SetFar = new("set_far");
     }
 }

--- a/addons/phantom_camera/scripts/resources/PhantomCameraNoise2D.cs
+++ b/addons/phantom_camera/scripts/resources/PhantomCameraNoise2D.cs
@@ -62,31 +62,31 @@ public class PhantomCameraNoise2D(Resource resource)
 
     public static class MethodName
     {
-        public const string GetAmplitude = "get_amplitude";
-        public const string SetAmplitude = "set_amplitude";
+        public static readonly StringName GetAmplitude = new("get_amplitude");
+        public static readonly StringName SetAmplitude = new("set_amplitude");
 
-        public const string GetFrequency = "get_frequency";
-        public const string SetFrequency = "set_frequency";
+        public static readonly StringName GetFrequency = new("get_frequency");
+        public static readonly StringName SetFrequency = new("set_frequency");
 
-        public const string GetRandomizeNoiseSeed = "get_randomize_noise_seed";
-        public const string SetRandomizeNoiseSeed = "set_randomize_noise_seed";
+        public static readonly StringName GetRandomizeNoiseSeed = new("get_randomize_noise_seed");
+        public static readonly StringName SetRandomizeNoiseSeed = new("set_randomize_noise_seed");
 
-        public const string GetNoiseSeed = "get_noise_seed";
-        public const string SetNoiseSeed = "set_noise_seed";
+        public static readonly StringName GetNoiseSeed = new("get_noise_seed");
+        public static readonly StringName SetNoiseSeed = new("set_noise_seed");
 
-        public const string GetRotationalNoise = "get_rotational_noise";
-        public const string SetRotationalNoise = "set_rotational_noise";
+        public static readonly StringName GetRotationalNoise = new("get_rotational_noise");
+        public static readonly StringName SetRotationalNoise = new("set_rotational_noise");
 
-        public const string GetPositionalNoise = "get_positional_noise";
-        public const string SetPositionalNoise = "set_positional_noise";
+        public static readonly StringName GetPositionalNoise = new("get_positional_noise");
+        public static readonly StringName SetPositionalNoise = new("set_positional_noise");
 
-        public const string GetRotationalMultiplier = "get_rotational_multiplier";
-        public const string SetRotationalMultiplier = "set_rotational_multiplier";
+        public static readonly StringName GetRotationalMultiplier = new("get_rotational_multiplier");
+        public static readonly StringName SetRotationalMultiplier = new("set_rotational_multiplier");
 
-        public const string GetPositionalMultiplierX = "get_positional_multiplier_x";
-        public const string SetPositionalMultiplierX = "set_positional_multiplier_x";
+        public static readonly StringName GetPositionalMultiplierX = new("get_positional_multiplier_x");
+        public static readonly StringName SetPositionalMultiplierX = new("set_positional_multiplier_x");
 
-        public const string GetPositionalMultiplierY = "get_positional_multiplier_y";
-        public const string SetPositionalMultiplierY = "set_positional_multiplier_y";
+        public static readonly StringName GetPositionalMultiplierY = new("get_positional_multiplier_y");
+        public static readonly StringName SetPositionalMultiplierY = new("set_positional_multiplier_y");
     }
 }

--- a/addons/phantom_camera/scripts/resources/PhantomCameraNoise3D.cs
+++ b/addons/phantom_camera/scripts/resources/PhantomCameraNoise3D.cs
@@ -80,40 +80,40 @@ public class PhantomCameraNoise3D(Resource resource)
 
     public static class MethodName
     {
-        public const string GetAmplitude = "get_amplitude";
-        public const string SetAmplitude = "set_amplitude";
+        public static readonly StringName GetAmplitude = new("get_amplitude");
+        public static readonly StringName SetAmplitude = new("set_amplitude");
 
-        public const string GetFrequency = "get_frequency";
-        public const string SetFrequency = "set_frequency";
+        public static readonly StringName GetFrequency = new("get_frequency");
+        public static readonly StringName SetFrequency = new("set_frequency");
 
-        public const string GetRandomizeNoiseSeed = "get_randomize_noise_seed";
-        public const string SetRandomizeNoiseSeed = "set_randomize_noise_seed";
+        public static readonly StringName GetRandomizeNoiseSeed = new("get_randomize_noise_seed");
+        public static readonly StringName SetRandomizeNoiseSeed = new("set_randomize_noise_seed");
 
-        public const string GetNoiseSeed = "get_noise_seed";
-        public const string SetNoiseSeed = "set_noise_seed";
+        public static readonly StringName GetNoiseSeed = new("get_noise_seed");
+        public static readonly StringName SetNoiseSeed = new("set_noise_seed");
 
-        public const string GetRotationalNoise = "get_rotational_noise";
-        public const string SetRotationalNoise = "set_rotational_noise";
+        public static readonly StringName GetRotationalNoise = new("get_rotational_noise");
+        public static readonly StringName SetRotationalNoise = new("set_rotational_noise");
 
-        public const string GetPositionalNoise = "get_positional_noise";
-        public const string SetPositionalNoise = "set_positional_noise";
+        public static readonly StringName GetPositionalNoise = new("get_positional_noise");
+        public static readonly StringName SetPositionalNoise = new("set_positional_noise");
 
-        public const string GetRotationalMultiplierX = "get_rotational_multiplier_x";
-        public const string SetRotationalMultiplierX = "set_rotational_multiplier_x";
+        public static readonly StringName GetRotationalMultiplierX = new("get_rotational_multiplier_x");
+        public static readonly StringName SetRotationalMultiplierX = new("set_rotational_multiplier_x");
 
-        public const string GetRotationalMultiplierY = "get_rotational_multiplier_y";
-        public const string SetRotationalMultiplierY = "set_rotational_multiplier_y";
+        public static readonly StringName GetRotationalMultiplierY = new("get_rotational_multiplier_y");
+        public static readonly StringName SetRotationalMultiplierY = new("set_rotational_multiplier_y");
 
-        public const string GetRotationalMultiplierZ = "get_rotational_multiplier_z";
-        public const string SetRotationalMultiplierZ = "set_rotational_multiplier_z";
+        public static readonly StringName GetRotationalMultiplierZ = new("get_rotational_multiplier_z");
+        public static readonly StringName SetRotationalMultiplierZ = new("set_rotational_multiplier_z");
 
-        public const string GetPositionalMultiplierX = "get_positional_multiplier_x";
-        public const string SetPositionalMultiplierX = "set_positional_multiplier_x";
+        public static readonly StringName GetPositionalMultiplierX = new("get_positional_multiplier_x");
+        public static readonly StringName SetPositionalMultiplierX = new("set_positional_multiplier_x");
 
-        public const string GetPositionalMultiplierY = "get_positional_multiplier_y";
-        public const string SetPositionalMultiplierY = "set_positional_multiplier_y";
+        public static readonly StringName GetPositionalMultiplierY = new("get_positional_multiplier_y");
+        public static readonly StringName SetPositionalMultiplierY = new("set_positional_multiplier_y");
 
-        public const string GetPositionalMultiplierZ = "get_positional_multiplier_z";
-        public const string SetPositionalMultiplierZ = "set_positional_multiplier_z";
+        public static readonly StringName GetPositionalMultiplierZ = new("get_positional_multiplier_z");
+        public static readonly StringName SetPositionalMultiplierZ = new("set_positional_multiplier_z");
     }
 }

--- a/addons/phantom_camera/scripts/resources/PhantomCameraTween.cs
+++ b/addons/phantom_camera/scripts/resources/PhantomCameraTween.cs
@@ -57,8 +57,8 @@ public class PhantomCameraTween(Resource tweenResource)
 
     public static class PropertyName
     {
-        public const string Duration = "duration";
-        public const string Transition = "transition";
-        public const string Ease = "ease";
+        public static readonly StringName Duration = new("duration");
+        public static readonly StringName Transition = new("transition");
+        public static readonly StringName Ease = new("ease");
     }
 }


### PR DESCRIPTION
Avoids new StringName allocation on each getter and setter for each property, which would've caused major spikes in the frame time as StringName allocations are quite expensive. See godotengine/godot#105750 for more info.