### PR TITLE
Add ignore_time_scale option to PhantomCamera

### DIFF
--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -791,6 +791,9 @@ var tween_transition: PhantomCameraTween.TransitionType:
 var tween_ease: PhantomCameraTween.EaseType:
 	set = set_tween_ease,
 	get = get_tween_ease
+var tween_ignore_time_scale: bool:
+	set = set_tween_ignore_time_scale,
+	get = get_tween_ignore_time_scale
 
 var keep_aspect: int:
 	set = set_keep_aspect,

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -2021,6 +2021,19 @@ func get_tween_ease() -> int:
 	else:
 		return 2 # Equals EaseType.EASE_IN_OUT
 
+
+## Assigns a new [param Tween Ignore Time Scale] to the [member tween_resource] value.[br]
+func set_tween_ignore_time_scale(value: bool) -> void:
+	tween_resource.ignore_time_scale = value
+
+## Gets the current [param Tween Ignore Time Scale] value.
+func get_tween_ignore_time_scale() -> bool:
+	if tween_resource:
+		return tween_resource.ignore_time_scale
+	else:
+		return false # Make tween follow time scale
+
+
 ## Sets the [param PhantomCamera3D] active state[br]
 ## [b][color=yellow]Important:[/color][/b] This value can only be changed
 ## from the [PhantomCameraHost] script.

--- a/addons/phantom_camera/scripts/resources/tween_resource.gd
+++ b/addons/phantom_camera/scripts/resources/tween_resource.gd
@@ -39,3 +39,6 @@ enum EaseType {
 
 ## The ease type for the tween. The options are defined in the [enum EaseType].
 @export var ease: EaseType = EaseType.EASE_IN_OUT
+
+## Whether the tween should ignore [member Engine.time_scale].
+@export var ignore_time_scale: bool = false;

--- a/addons/phantom_camera/scripts/resources/tween_resource.gd
+++ b/addons/phantom_camera/scripts/resources/tween_resource.gd
@@ -41,4 +41,4 @@ enum EaseType {
 @export var ease: EaseType = EaseType.EASE_IN_OUT
 
 ## Whether the tween should ignore [member Engine.time_scale].
-@export var ignore_time_scale: bool = false;
+@export var ignore_time_scale: bool = false


### PR DESCRIPTION
Pull request to introduce support for ignoring `Engine.time_scale` in PhantomCamera tweens, by enabling this option, camera transitions operate independently of the engine’s global time scaling, ensuring the camera behavior is not affected whether the game is paused, slowed down, or sped up.

**Not sure yet how to implement this, but I will update this pull request as I go, please let me know if I mess something up.**

Fix #641.