### PR TITLE
fix: add early return guard in set_priority()

### DIFF
--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
@@ -1357,12 +1357,13 @@ func get_zoom() -> Vector2:
 
 ## Assigns new [member priority] value.
 func set_priority(value: int) -> void:
-	if priority == value: return
+	if priority == maxi(0, value): 
+		push_warning("Newly assigned priority value of " + name + " is identical to current.")
+		return
 	priority = maxi(0, value)
 	if not is_node_ready(): return
 	if not Engine.has_singleton(_constants.PCAM_MANAGER_NODE_NAME): return
 	Engine.get_singleton(_constants.PCAM_MANAGER_NODE_NAME).pcam_priority_changed.emit(self)
-
 ## Gets current [member priority] value.
 func get_priority() -> int:
 	return priority

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
@@ -1357,10 +1357,11 @@ func get_zoom() -> Vector2:
 
 ## Assigns new [member priority] value.
 func set_priority(value: int) -> void:
-	if priority == maxi(0, value): 
+	var new_priority: int = maxi(0, value)
+	if priority == new_priority: 
 		push_warning("Newly assigned priority value of " + name + " is identical to current.")
 		return
-	priority = maxi(0, value)
+	priority = new_priority
 	if not is_node_ready(): return
 	if not Engine.has_singleton(_constants.PCAM_MANAGER_NODE_NAME): return
 	Engine.get_singleton(_constants.PCAM_MANAGER_NODE_NAME).pcam_priority_changed.emit(self)

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
@@ -1357,6 +1357,7 @@ func get_zoom() -> Vector2:
 
 ## Assigns new [member priority] value.
 func set_priority(value: int) -> void:
+	if priority == value: return
 	priority = maxi(0, value)
 	if not is_node_ready(): return
 	if not Engine.has_singleton(_constants.PCAM_MANAGER_NODE_NAME): return

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -1965,7 +1965,9 @@ func get_tween_skip() -> bool:
 
 ## Assigns new [member priority] value.
 func set_priority(value: int) -> void:
-	if priority == value: return
+	if priority == maxi(0, value): 
+		push_warning("Newly assigned priority value of " + name + " is identical to current.")
+		return
 	priority = maxi(0, value)
 	if not is_node_ready(): return
 	if not Engine.has_singleton(_constants.PCAM_MANAGER_NODE_NAME): return

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -1965,10 +1965,11 @@ func get_tween_skip() -> bool:
 
 ## Assigns new [member priority] value.
 func set_priority(value: int) -> void:
+	if priority == value: return
 	priority = maxi(0, value)
 	if not is_node_ready(): return
 	if not Engine.has_singleton(_constants.PCAM_MANAGER_NODE_NAME): return
-	Engine.get_singleton(_constants.PCAM_MANAGER_NODE_NAME).pcam_priority_changed.emit(self)
+	Engine.get_singleton(_constants.PCAM_MANAGER_NODE_NAME).emit(self)
 ## Gets current [param Priority] value.
 func get_priority() -> int:
 	return priority

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -1965,10 +1965,11 @@ func get_tween_skip() -> bool:
 
 ## Assigns new [member priority] value.
 func set_priority(value: int) -> void:
-	if priority == maxi(0, value): 
+	var new_priority: int = maxi(0, value)
+	if priority == new_priority: 
 		push_warning("Newly assigned priority value of " + name + " is identical to current.")
 		return
-	priority = maxi(0, value)
+	priority = new_priority
 	if not is_node_ready(): return
 	if not Engine.has_singleton(_constants.PCAM_MANAGER_NODE_NAME): return
 	Engine.get_singleton(_constants.PCAM_MANAGER_NODE_NAME).pcam_priority_changed.emit(self)

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -1969,7 +1969,7 @@ func set_priority(value: int) -> void:
 	priority = maxi(0, value)
 	if not is_node_ready(): return
 	if not Engine.has_singleton(_constants.PCAM_MANAGER_NODE_NAME): return
-	Engine.get_singleton(_constants.PCAM_MANAGER_NODE_NAME).emit(self)
+	Engine.get_singleton(_constants.PCAM_MANAGER_NODE_NAME).pcam_priority_changed.emit(self)
 ## Gets current [param Priority] value.
 func get_priority() -> int:
 	return priority


### PR DESCRIPTION
Prevent redundant update & signal emits even when the value hasn't actually changed