### PR TITLE
fix: Avoid accidental `PCam3D.up_target` invalidation

### DIFF
--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -1324,28 +1324,28 @@ func _set_follow_position(delta: float) -> void:
 						_follow_target_position = global_position
 						_current_rotation = global_rotation
 						return
-			else:
-				_follow_target_output_position = target_position + transform.basis.z * follow_distance
-				var unprojected_position: Vector2 = _get_raw_unprojected_position()
-				var viewport_width: float = get_viewport().size.x
-				var viewport_height: float = get_viewport().size.y
-				var camera_aspect: int = get_viewport().get_camera_3d().keep_aspect
-				var visible_rect_size: Vector2 = get_viewport().get_visible_rect().size
+			# else:
+			# 	_follow_target_output_position = target_position + transform.basis.z * follow_distance
+			# 	var unprojected_position: Vector2 = _get_raw_unprojected_position()
+			# 	var viewport_width: float = get_viewport().size.x
+			# 	var viewport_height: float = get_viewport().size.y
+			# 	var camera_aspect: int = get_viewport().get_camera_3d().keep_aspect
+			# 	var visible_rect_size: Vector2 = get_viewport().get_visible_rect().size
 
-				unprojected_position = unprojected_position - visible_rect_size / 2
-				if camera_aspect == Camera3D.KEEP_HEIGHT:
-					# Landscape View
-					var aspect_ratio_scale: float = viewport_width / viewport_height
-					unprojected_position.x = (unprojected_position.x / aspect_ratio_scale + 1) / 2
-					unprojected_position.y = (unprojected_position.y + 1) / 2
-				else:
-					# Portrait View
-					var aspect_ratio_scale: float = viewport_height / viewport_width
-					unprojected_position.x = (unprojected_position.x + 1) / 2
-					unprojected_position.y = (unprojected_position.y / aspect_ratio_scale + 1) / 2
+			# 	unprojected_position = unprojected_position - visible_rect_size / 2
+			# 	if camera_aspect == Camera3D.KEEP_HEIGHT:
+			# 		# Landscape View
+			# 		var aspect_ratio_scale: float = viewport_width / viewport_height
+			# 		unprojected_position.x = (unprojected_position.x / aspect_ratio_scale + 1) / 2
+			# 		unprojected_position.y = (unprojected_position.y + 1) / 2
+			# 	else:
+			# 		# Portrait View
+			# 		var aspect_ratio_scale: float = viewport_height / viewport_width
+			# 		unprojected_position.x = (unprojected_position.x + 1) / 2
+			# 		unprojected_position.y = (unprojected_position.y / aspect_ratio_scale + 1) / 2
 
-				viewport_position = unprojected_position
-				_set_follow_gizmo_line_position(follow_target.global_position)
+			# 	viewport_position = unprojected_position
+			# 	_set_follow_gizmo_line_position(follow_target.global_position)
 
 		FollowMode.THIRD_PERSON:
 			if not Engine.is_editor_hint():
@@ -1847,8 +1847,15 @@ func _look_at_target_tree_exiting(target: Node) -> void:
 	if look_at_targets.has(target):
 		erase_look_at_targets(target)
 
+
 func _up_target_tree_exiting() -> void:
-	up_target = null
+	# This check prevents accidental [up_target] invalidation.
+	# Unlike comparing the owner to [get_tree().edited_scene_root], this approach returns [true] 
+	# when the [up_target] exits the tree while in the same scene, and [false] if the edited scene 
+	# has changed in the process, like when closing the owner scene or changing to another one in editor.
+	if not Engine.is_editor_hint() or \
+	Engine.get_singleton(&"EditorInterface").get_edited_scene_root() == owner: 
+		up_target = null
 
 
 func _should_look_at_checker() -> void:

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -1324,28 +1324,6 @@ func _set_follow_position(delta: float) -> void:
 						_follow_target_position = global_position
 						_current_rotation = global_rotation
 						return
-			# else:
-			# 	_follow_target_output_position = target_position + transform.basis.z * follow_distance
-			# 	var unprojected_position: Vector2 = _get_raw_unprojected_position()
-			# 	var viewport_width: float = get_viewport().size.x
-			# 	var viewport_height: float = get_viewport().size.y
-			# 	var camera_aspect: int = get_viewport().get_camera_3d().keep_aspect
-			# 	var visible_rect_size: Vector2 = get_viewport().get_visible_rect().size
-
-			# 	unprojected_position = unprojected_position - visible_rect_size / 2
-			# 	if camera_aspect == Camera3D.KEEP_HEIGHT:
-			# 		# Landscape View
-			# 		var aspect_ratio_scale: float = viewport_width / viewport_height
-			# 		unprojected_position.x = (unprojected_position.x / aspect_ratio_scale + 1) / 2
-			# 		unprojected_position.y = (unprojected_position.y + 1) / 2
-			# 	else:
-			# 		# Portrait View
-			# 		var aspect_ratio_scale: float = viewport_height / viewport_width
-			# 		unprojected_position.x = (unprojected_position.x + 1) / 2
-			# 		unprojected_position.y = (unprojected_position.y / aspect_ratio_scale + 1) / 2
-
-			# 	viewport_position = unprojected_position
-			# 	_set_follow_gizmo_line_position(follow_target.global_position)
 
 		FollowMode.THIRD_PERSON:
 			if not Engine.is_editor_hint():

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -1124,13 +1124,6 @@ func _process(delta: float) -> void:
 	process_logic(delta)
 
 
-func _notification(what: int) -> void:
-	match(what):
-		NOTIFICATION_EDITOR_PRE_SAVE:
-			if up_target and !up_target.is_inside_tree():
-				up_target = null
-
-
 func process_logic(delta: float) -> void:
 	if _is_active:
 		if _has_noise_resource and _preview_noise:

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -1124,6 +1124,12 @@ func _process(delta: float) -> void:
 	process_logic(delta)
 
 
+func _notification(what: int) -> void:
+	match(what):
+		NOTIFICATION_EDITOR_PRE_SAVE:
+			if up_target and !up_target.is_inside_tree():
+				up_target = null
+
 
 func process_logic(delta: float) -> void:
 	if _is_active:
@@ -1827,13 +1833,7 @@ func _look_at_target_tree_exiting(target: Node) -> void:
 
 
 func _up_target_tree_exiting() -> void:
-	# This check prevents accidental [up_target] invalidation.
-	# Unlike comparing the owner to [get_tree().edited_scene_root], this approach returns [true] 
-	# when the [up_target] exits the tree while in the same scene, and [false] if the edited scene 
-	# has changed in the process, like when closing the owner scene or changing to another one in editor.
-	if not Engine.is_editor_hint() or \
-	Engine.get_singleton(&"EditorInterface").get_edited_scene_root() == owner: 
-		up_target = null
+	_has_up_target = false
 
 
 func _should_look_at_checker() -> void:


### PR DESCRIPTION
The `PCam3D.up_target` property was getting invalidated when changing scenes in the editor. 
Added a check to determine if the node is actually in the process of exiting the scene or if its `tree_exiting()` signal fired as part of a scene change in editor.

We began using this feature a decent amount for trippy scenes in our game and noticed we had to keep setting the property over and over. Thought it was an inherited scene or extended script issue but was able to replicate the issue in **dev_scene_3d.tscn** too.

I also took the liberty to comment out a portion of the script that was making the script unable to parse (I assumed it was an older implementation).