### PR TITLE
Added toggle for mixed LookAt+Follow mode warning in ProjectSettings

### DIFF
--- a/addons/phantom_camera/plugin.gd
+++ b/addons/phantom_camera/plugin.gd
@@ -21,6 +21,7 @@ const PHANTOM_CAMERA_MANAGER: StringName = "PhantomCameraManager"
 #region Private Variables
 
 var _settings_show_jitter_tips: String = "phantom_camera/tips/show_jitter_tips"
+var _settings_show_mixed_mode_tips: String = "phantom_camera/tips/show_mixed_mode_tips"
 var _settings_enable_editor_shortcut: String = "phantom_camera/general/enable_editor_shortcut"
 var _settings_editor_shortcut: String = "phantom_camera/general/editor_shortcut"
 
@@ -99,6 +100,17 @@ func _enter_tree() -> void:
 	})
 	ProjectSettings.set_initial_value(_settings_show_jitter_tips, true)
 	ProjectSettings.set_as_basic(_settings_show_jitter_tips, true)
+	
+	## Setting for enabling / disabling mixed Follow + LookAt modes in the output
+	if not ProjectSettings.has_setting(_settings_show_mixed_mode_tips):
+		ProjectSettings.set_setting(_settings_show_mixed_mode_tips, true)
+		ProjectSettings
+	ProjectSettings.add_property_info({
+		"name": _settings_show_mixed_mode_tips,
+		"type": TYPE_BOOL,
+	})
+	ProjectSettings.set_initial_value(_settings_show_mixed_mode_tips, true)
+	ProjectSettings.set_as_basic(_settings_show_mixed_mode_tips, true)
 
 
 # 	TODO - Pending merge of https://github.com/godotengine/godot/pull/102889 - Should only support Godot version after this release

--- a/addons/phantom_camera/plugin.gd
+++ b/addons/phantom_camera/plugin.gd
@@ -101,7 +101,7 @@ func _enter_tree() -> void:
 	ProjectSettings.set_initial_value(_settings_show_jitter_tips, true)
 	ProjectSettings.set_as_basic(_settings_show_jitter_tips, true)
 	
-	## Setting for enabling / disabling mixed Follow + LookAt modes in the output
+	## Setting for enabling / disabling mixed Follow + LookAt mode tips in the output
 	if not ProjectSettings.has_setting(_settings_show_mixed_mode_tips):
 		ProjectSettings.set_setting(_settings_show_mixed_mode_tips, true)
 		ProjectSettings

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
@@ -1193,7 +1193,7 @@ func _check_physics_body(target: Node2D) -> void:
 			_rigid_body_2d = target as RigidBody2D
 			_follow_target_physics_class = FollowTargetPhysicsClass.RIGIDBODY
 
-		var show_jitter_tips := ProjectSettings.get_setting("phantom_camera/tips/show_jitter_tips")
+		var show_jitter_tips := ProjectSettings.get_setting(_constants.SETTING_JITTER_TIPS)
 		var physics_interpolation_enabled := ProjectSettings.get_setting("physics/common/physics_interpolation")
 
 		## NOTE - Feature Toggle

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -209,9 +209,12 @@ enum FollowTargetPhysicsClass {
 
 		notify_property_list_changed()
 
+		var show_mixed_mode_tips := ProjectSettings.get_setting("phantom_camera/tips/show_mixed_mode_tips")
+
 		## NOTE - Warning that Look At + Follow Mode hasn't been fully tested together yet
-		if look_at_mode != LookAtMode.NONE:
+		if look_at_mode != LookAtMode.NONE and show_mixed_mode_tips:
 			print_rich("[color=#EAA15E]Warning: Using both Look At and Follow Mode on the same PCam3D has not been fully tested yet, proceed with caution![/color]")
+			print_rich("This tip can be disabled from within [code]Project Settings / Phantom Camera / Tips / Show Mixed Mode Tips[/code]")
 	get:
 		return follow_mode
 
@@ -267,9 +270,12 @@ enum FollowTargetPhysicsClass {
 
 		notify_property_list_changed()
 
+		var show_mixed_mode_tips := ProjectSettings.get_setting("phantom_camera/tips/show_mixed_mode_tips")
+
 		## NOTE - Warning that Look At + Follow Mode hasn't been fully tested together yet
-		if follow_mode != FollowMode.NONE:
+		if not follow_mode == FollowMode.NONE and show_mixed_mode_tips:
 			print_rich("[color=#EAA15E]Warning: Using both Look At and Follow Mode on the same PCam3D has not been fully tested yet, proceed with caution![/color]")
+			print_rich("This tip can be disabled from within [code]Project Settings / Phantom Camera / Tips / Show Mixed Mode Tips[/code]")
 	get:
 		return look_at_mode
 

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -273,7 +273,7 @@ enum FollowTargetPhysicsClass {
 		var show_mixed_mode_tips := ProjectSettings.get_setting("phantom_camera/tips/show_mixed_mode_tips")
 
 		## NOTE - Warning that Look At + Follow Mode hasn't been fully tested together yet
-		if not follow_mode == FollowMode.NONE and show_mixed_mode_tips:
+		if follow_mode != FollowMode.NONE and show_mixed_mode_tips:
 			print_rich("[color=#EAA15E]Warning: Using both Look At and Follow Mode on the same PCam3D has not been fully tested yet, proceed with caution![/color]")
 			print_rich("This tip can be disabled from within [code]Project Settings / Phantom Camera / Tips / Show Mixed Mode Tips[/code]")
 	get:

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_3d.gd
@@ -209,7 +209,7 @@ enum FollowTargetPhysicsClass {
 
 		notify_property_list_changed()
 
-		var show_mixed_mode_tips := ProjectSettings.get_setting("phantom_camera/tips/show_mixed_mode_tips")
+		var show_mixed_mode_tips := ProjectSettings.get_setting(_constants.SETTING_MIXED_MODE_TIPS)
 
 		## NOTE - Warning that Look At + Follow Mode hasn't been fully tested together yet
 		if look_at_mode != LookAtMode.NONE and show_mixed_mode_tips:
@@ -270,7 +270,7 @@ enum FollowTargetPhysicsClass {
 
 		notify_property_list_changed()
 
-		var show_mixed_mode_tips := ProjectSettings.get_setting("phantom_camera/tips/show_mixed_mode_tips")
+		var show_mixed_mode_tips := ProjectSettings.get_setting(_constants.SETTING_MIXED_MODE_TIPS)
 
 		## NOTE - Warning that Look At + Follow Mode hasn't been fully tested together yet
 		if follow_mode != FollowMode.NONE and show_mixed_mode_tips:

--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_constants.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_constants.gd
@@ -27,3 +27,10 @@ const PCAM_GROUP_NAME: StringName = "phantom_camera_group"
 const PCAM_HOST_GROUP_NAME: StringName = "phantom_camera_host_group"
 
 #endregion
+
+#region Setting Names
+
+const SETTING_JITTER_TIPS: String = "phantom_camera/tips/show_jitter_tips"
+const SETTING_MIXED_MODE_TIPS: String = "phantom_camera/tips/show_mixed_mode_tips"
+
+#endregion


### PR DESCRIPTION
I found myself disabling this warning message manually across many projects, so I figured a toggle in `ProjectSettings` would be useful. Works similarly to Jitter Tips.

Not sure if "Mixed Mode Tips" is the best name for the setting, but I couldn't come up with something that wasn't wordier. 

<img width="927" height="52" alt="20260822_004037" src="https://github.com/user-attachments/assets/38813e14-bd01-489d-9850-6716ca20479c" />
<img width="627" height="211" alt="image" src="https://github.com/user-attachments/assets/209f7385-413c-4aff-bea4-a6c12f22c446" />



