### PR TITLE
Add missing `#endregion` in `phantom_camera_2d.gd`

### DIFF
--- a/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
+++ b/addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd
@@ -509,6 +509,8 @@ var _should_rotate_with_target: bool = false
 	set = set_noise_emitter_layer,
 	get = get_noise_emitter_layer
 
+#endregion
+
 #region Private Variables
 
 var _is_active: bool = false


### PR DESCRIPTION
The Exported Properties `#region` was missing it's `#endregion` in `phantom_camera_2d.gd`.