### PR TITLE
fix: eliminate PhantomCameraHost C# compiler warnings

### DIFF
--- a/addons/phantom_camera/scripts/phantom_camera_host/PhantomCameraHost.cs
+++ b/addons/phantom_camera/scripts/phantom_camera_host/PhantomCameraHost.cs
@@ -1,3 +1,4 @@
+using System;
 using Godot;
 
 #nullable enable
@@ -26,13 +27,13 @@ public class PhantomCameraHost()
 
     public PhantomCameraHost(GodotObject node) : this()
     {
-        Node = node as Node;
+        Node = node as Node ?? throw new ArgumentException("Expected a Godot Node.", nameof(node));
 
-        var callablePCamBecameActive = Callable.From<Node>(pCam => PCamBecameActive?.Invoke(pCam));
-        var callablePCamBecameInactive = Callable.From<Node>(pCam => PCamBecameInactive?.Invoke(pCam));
+        _callablePCamBecameActive = Callable.From<Node>(pCam => PCamBecameActive?.Invoke(pCam));
+        _callablePCamBecameInactive = Callable.From<Node>(pCam => PCamBecameInactive?.Invoke(pCam));
 
-        Node.Connect(SignalName.PCamBecameActive, callablePCamBecameActive);
-        Node.Connect(SignalName.PCamBecameInactive, callablePCamBecameInactive);
+        Node.Connect(SignalName.PCamBecameActive, _callablePCamBecameActive);
+        Node.Connect(SignalName.PCamBecameInactive, _callablePCamBecameInactive);
     }
 
     public delegate void PCamBecameActiveEventHandler(Node pCam);


### PR DESCRIPTION
## Summary

Fix the four C# compiler warnings emitted by `PhantomCameraHost.cs` when the plugin is built with nullable reference types enabled.

- Validate that the `GodotObject` passed to `PhantomCameraHost(GodotObject)` is a `Node` before assigning `Node`.
- Store the two signal `Callable` instances in the existing readonly fields and connect those stored instances.
- Preserve the public parameterless constructor and the normal `Node`-wrapper construction path.

## Root cause

The constructor used `node as Node`, which can produce `null`, then immediately dereferenced `Node` for `Connect`. This produced:

- `CS8601`: possible null assignment
- `CS8602`: possible null dereference

The class already declared `_callablePCamBecameActive` and `_callablePCamBecameInactive`, but constructed and connected separate local callables instead. That produced two `CS0169` warnings for unused fields.

## Behavior and compatibility

For valid callers, the created callbacks, event forwarding, signal names, and connection order are unchanged. The existing public parameterless constructor is retained.

For an invalid non-`Node` `GodotObject`, construction now fails immediately with `ArgumentException`; previously it failed later when attempting to call `Connect` on a null node reference. The stored callables match the fields already present in the class and make their intended ownership explicit.

## Validation

- `dotnet restore PhantomCamera.sln`
- `dotnet build PhantomCamera.sln --no-restore`

Result: `0 Warning(s), 0 Error(s)`.